### PR TITLE
allow using QtAVPlayer as library in qmake-based projects

### DIFF
--- a/QtAVPlayerLib.pri
+++ b/QtAVPlayerLib.pri
@@ -1,0 +1,81 @@
+isEmpty(QTAVPLAYER) {
+    QTAVPLAYER = $$(QTAVPLAYER)
+}
+message('QTAVPLAYER: ' $$QTAVPLAYER)
+
+FFMPEG = $$(FFMPEG)
+message('FFMPEG: ' $$FFMPEG)
+!isEmpty(FFMPEG) {
+
+    oldConf = $$cat($$QTAVPLAYER/.qmake.conf.backup, lines)
+    isEmpty(oldConf) {
+        oldConf = $$cat($$QTAVPLAYER/.qmake.conf, lines)
+        message('writting backup of original .qmake.conf')
+        write_file($$QTAVPLAYER/.qmake.conf.backup, oldConf)
+    } else {
+        message('reading backup of original .qmake.conf.backup')
+    }
+
+    message('oldConf: ' $$oldConf)
+    write_file($$QTAVPLAYER/.qmake.conf, oldConf)
+
+    exists($$FFMPEG/include) {
+        FFMPEG_INCLUDES=$$absolute_path($$FFMPEG/include)
+    } else {
+        FFMPEG_INCLUDES=$$FFMPEG
+    }
+
+    exists($$absolute_path($$FFMPEG/lib)) {
+        FFMPEG_LIBS += -L$$absolute_path($$FFMPEG/lib) \
+                    -lavdevice \
+                    -lavcodec \
+                    -lavfilter \
+                    -lavformat \
+                    -lpostproc \
+                    -lswresample \
+                    -lswscale \
+                    -lavutil
+
+        FFMPEG_EXTRA_LIBS += $$absolute_path($$FFMPEG/lib)
+    } else {
+        FFMPEG_AVDEVICE=$$absolute_path($$FFMPEG/libavdevice)
+        FFMPEG_AVCODEC=$$absolute_path($$FFMPEG/libavcodec)
+        FFMPEG_AVFILTER=$$absolute_path($$FFMPEG/libavfilter)
+        FFMPEG_AVFORMAT=$$absolute_path($$FFMPEG/libavformat)
+        FFMPEG_POSTPROC=$$absolute_path($$FFMPEG/libpostproc)
+        FFMPEG_SWRESAMPLE=$$absolute_path($$FFMPEG/libswresample)
+        FFMPEG_SWSCALE=$$absolute_path($$FFMPEG/libswscale)
+        FFMPEG_AVUTIL=$$absolute_path($$FFMPEG/libavutil)
+
+        FFMPEG_EXTRA_LIBS += \
+                        $$FFMPEG_AVDEVICE \
+                        $$FFMPEG_AVCODEC \
+                        $$FFMPEG_AVFILTER \
+                        $$FFMPEG_AVFORMAT \
+                        $$FFMPEG_POSTPROC \
+                        $$FFMPEG_SWRESAMPLE \
+                        $$FFMPEG_SWSCALE \
+                        $$FFMPEG_AVUTIL
+
+        FFMPEG_LIBS += \
+                     -L$$FFMPEG_AVDEVICE -lavdevice \
+                     -L$$FFMPEG_AVCODEC -lavcodec \
+                     -L$$FFMPEG_AVFILTER -lavfilter \
+                     -L$$FFMPEG_AVFORMAT -lavformat \
+                     -L$$FFMPEG_POSTPROC -lpostproc \
+                     -L$$FFMPEG_SWRESAMPLE -lswresample \
+                     -L$$FFMPEG_SWSCALE -lswscale \
+                     -L$$FFMPEG_AVUTIL -lavutil
+    }
+
+    ffmpegIncludes = "INCLUDEPATH+=$$FFMPEG_INCLUDES"
+    ffmpegLibs = "LIBS+=$$FFMPEG_LIBS"
+    ffmpegExtraIncludes = "EXTRA_INCLUDEPATH+=$$FFMPEG_INCLUDES"
+    ffmpegExtraLibs = "EXTRA_LIBDIR+=$$FFMPEG_EXTRA_LIBS"
+
+    write_file($$QTAVPLAYER/.qmake.conf, ffmpegIncludes, append)
+    write_file($$QTAVPLAYER/.qmake.conf, ffmpegLibs, append)
+
+    write_file($$QTAVPLAYER/.qmake.conf, ffmpegExtraIncludes, append)
+    write_file($$QTAVPLAYER/.qmake.conf, ffmpegExtraLibs, append)
+}

--- a/QtAVPlayerLib.pro
+++ b/QtAVPlayerLib.pro
@@ -1,0 +1,12 @@
+requires(qtHaveModule(multimedia))
+
+load(qt_configure)
+
+load(qt_build_config)
+
+TEMPLATE = subdirs
+
+exists($$_PRO_FILE_PWD_/src/srclib.pro) {
+    sub_src.file = $$_PRO_FILE_PWD_/src/srclib.pro
+    SUBDIRS += sub_src
+}

--- a/examples/examples_lib.pro
+++ b/examples/examples_lib.pro
@@ -1,0 +1,15 @@
+QTAVPLAYER = $$absolute_path($$_PRO_FILE_PWD_/..)
+message('QTAVPLAYER: ' $$QTAVPLAYER)
+
+include(../QtAVPlayerLib.pri)
+
+TEMPLATE = subdirs
+
+SUBDIRS += \
+    qml_video \
+    qtavplayerlib
+
+qml_video.file = qml_video/qml_video_lib.pro
+qtavplayerlib.file = $$QTAVPLAYER/QtAVPlayerLib.pro
+
+qml_video.depends = qtavplayerlib

--- a/examples/qml_video/qml_video_lib.pro
+++ b/examples/qml_video/qml_video_lib.pro
@@ -1,0 +1,33 @@
+QT += quick multimedia qtmultimediaquicktools-private
+
+CONFIG += c++14
+
+# You can make your code fail to compile if it uses deprecated APIs.
+# In order to do so, uncomment the following line.
+#DEFINES += QT_DISABLE_DEPRECATED_BEFORE=0x060000    # disables all the APIs deprecated before Qt 6.0.0
+
+SOURCES += \
+        main.cpp
+
+RESOURCES += qml.qrc
+
+# Additional import path used to resolve QML modules in Qt Creator's code model
+QML_IMPORT_PATH =
+
+# Additional import path used to resolve QML modules just for Qt Quick Designer
+QML_DESIGNER_IMPORT_PATH =
+
+# Default rules for deployment.
+qnx: target.path = /tmp/$${TARGET}/bin
+else: unix:!android: target.path = /opt/$${TARGET}/bin
+!isEmpty(target.path): INSTALLS += target
+
+INCLUDEPATH += $$absolute_path(../../src) $$absolute_path(../../src/QtAVPlayer)
+message('qml_video_lib INCLUDEPATH: ' $$INCLUDEPATH)
+
+win32: {
+    LIBS += -L../../src/QtAVPlayer/debug -lQtAVPlayer
+}
+!win32: {
+    LIBS += -L../../src/QtAVPlayer -lQtAVPlayer
+}

--- a/src/QtAVPlayer/QtAVPlayer
+++ b/src/QtAVPlayer/QtAVPlayer
@@ -1,0 +1,12 @@
+#ifndef QT_QTAVPLAYER_MODULE_H
+#define QT_QTAVPLAYER_MODULE_H
+#include <QtMultimedia/QtMultimedia>
+#include <QtConcurrent/QtConcurrent>
+#include "qtavplayerglobal.h"
+#include "qavaudioformat.h"
+#include "qavaudioframe.h"
+#include "qavaudiooutput.h"
+#include "qavframe.h"
+#include "qavplayer.h"
+#include "qavvideoframe.h"
+#endif

--- a/src/QtAVPlayer/QtAVPlayerLib.pro
+++ b/src/QtAVPlayer/QtAVPlayerLib.pro
@@ -1,0 +1,94 @@
+TARGET = QtAVPlayer
+MODULE = QtAVPlayer
+
+QT = multimedia concurrent
+QT_PRIVATE += gui-private
+
+INCLUDEPATH += $$absolute_path($$PWD/..)
+message ("INCLUDEPATH: " $$INCLUDEPATH)
+
+#QMAKE_USE += ffmpeg
+
+PRIVATE_HEADERS += \
+    qavcodec_p.h \
+    qavcodec_p_p.h \
+    qavaudiocodec_p.h \
+    qavvideocodec_p.h \
+    qavhwdevice_p.h \
+    qavdemuxer_p.h \
+    qavpacket_p.h \
+    qavframe_p.h \
+    qavpacketqueue_p.h \
+    qavvideobuffer_p.h \
+    qavvideobuffer_cpu_p.h \
+    qavvideobuffer_gpu_p.h
+
+PUBLIC_HEADERS += \
+    qavaudioformat.h \
+    qavframe.h \
+    qavvideoframe.h \
+    qavaudioframe.h \    
+    qtavplayerglobal.h \
+    qavaudiooutput.h \
+    qavplayer.h
+
+SOURCES += \
+    qavaudiooutput.cpp \
+    qavplayer.cpp \
+    qavcodec.cpp \
+    qavaudiocodec.cpp \
+    qavvideocodec.cpp \
+    qavdemuxer.cpp \
+    qavpacket.cpp \
+    qavframe.cpp \
+    qavvideoframe.cpp \
+    qavaudioframe.cpp \
+    qavvideobuffer_cpu.cpp \
+    qavvideobuffer_gpu.cpp
+
+qtConfig(va_x11):qtConfig(opengl): {
+    QMAKE_USE += va_x11 x11
+    PRIVATE_HEADERS += qavhwdevice_vaapi_x11_glx_p.h
+    SOURCES += qavhwdevice_vaapi_x11_glx.cpp
+}
+
+qtConfig(va_drm):qtConfig(egl): {
+    QMAKE_USE += va_drm egl
+    PRIVATE_HEADERS += qavhwdevice_vaapi_drm_egl_p.h
+    SOURCES += qavhwdevice_vaapi_drm_egl.cpp
+}
+
+macos|darwin {
+    PRIVATE_HEADERS += qavhwdevice_videotoolbox_p.h
+    SOURCES += qavhwdevice_videotoolbox.mm
+    LIBS += -framework CoreVideo -framework Metal -framework CoreMedia -framework QuartzCore -framework IOSurface
+}
+
+win32 {
+    PRIVATE_HEADERS += qavhwdevice_d3d11_p.h
+    SOURCES += qavhwdevice_d3d11.cpp
+}
+
+android {
+    PRIVATE_HEADERS += qavhwdevice_mediacodec_p.h
+    SOURCES += qavhwdevice_mediacodec.cpp
+
+    LIBS += -lavcodec -lavformat -lswscale -lavutil -lswresample
+    equals(ANDROID_TARGET_ARCH, armeabi-v7a): \
+        LIBS += -L$$(AVPLAYER_ANDROID_LIB_ARMEABI_V7A)
+
+    equals(ANDROID_TARGET_ARCH, arm64-v8a): \
+        LIBS += -L$$(AVPLAYER_ANDROID_LIB_ARMEABI_V8A)
+
+    equals(ANDROID_TARGET_ARCH, x86): \
+        LIBS += -L$$(AVPLAYER_ANDROID_LIB_X86)
+
+    equals(ANDROID_TARGET_ARCH, x86_64): \
+        LIBS += -L$$(AVPLAYER_ANDROID_LIB_X86_64)
+}
+
+HEADERS += $$PUBLIC_HEADERS $$PRIVATE_HEADERS
+#load(qt_module)
+
+TEMPLATE = lib
+DEFINES += QT_BUILD_AVPLAYER_LIB

--- a/src/srclib.pro
+++ b/src/srclib.pro
@@ -1,0 +1,7 @@
+TEMPLATE = subdirs
+
+include($$OUT_PWD/QtAVPlayer/qtQtAVPlayer-config.pri)
+QT_FOR_CONFIG += aplayer-private
+
+sub_src.file = QtAVPlayer/QtAVPlayerlib.pro
+SUBDIRS += sub_src

--- a/tests/auto/integration/QtAVPlayerLib.pri
+++ b/tests/auto/integration/QtAVPlayerLib.pri
@@ -1,0 +1,12 @@
+QTAVPLAYER = $$absolute_path(../../..)
+INCLUDEPATH += $$QTAVPLAYER/src $$QTAVPLAYER/src/QtAVPlayer
+DEFINES += QTAVPLAYERLIB
+
+message('QTAVPLAYER: ' $$QTAVPLAYER)
+
+win32: {
+    LIBS += -L$$QTAVPLAYER/src/QtAVPlayer/debug -lQtAVPlayer
+}
+!win32: {
+    LIBS += -L$$QTAVPLAYER/src/QtAVPlayer -lQtAVPlayer
+}

--- a/tests/auto/integration/integration_lib.pro
+++ b/tests/auto/integration/integration_lib.pro
@@ -1,0 +1,15 @@
+QTAVPLAYER = $$absolute_path($$_PRO_FILE_PWD_/../../..)
+message('QTAVPLAYER: ' $$QTAVPLAYER)
+
+include(../../../QtAVPlayerLib.pri)
+
+TEMPLATE = subdirs
+
+SUBDIRS += qavdemuxer qavplayer qtavplayerlib
+
+qavdemuxer.file = qavdemuxer/qavdemuxer_lib.pro
+qavplayer.file = qavplayer/qavplayer_lib.pro
+qtavplayerlib.file = $$QTAVPLAYER/QtAVPlayerLib.pro
+
+qavdemuxer.depends = qtavplayerlib
+qavplayer.depends = qtavplayerlib

--- a/tests/auto/integration/qavdemuxer/qavdemuxer_lib.pro
+++ b/tests/auto/integration/qavdemuxer/qavdemuxer_lib.pro
@@ -1,0 +1,11 @@
+TARGET = tst_qavdemuxer
+
+QT += multimedia-private testlib
+
+include(../QtAVPlayerLib.pri)
+
+CONFIG += testcase
+
+SOURCES += \
+    tst_qavdemuxer.cpp
+

--- a/tests/auto/integration/qavdemuxer/tst_qavdemuxer.cpp
+++ b/tests/auto/integration/qavdemuxer/tst_qavdemuxer.cpp
@@ -5,12 +5,17 @@
  * Free Qt Media Player based on FFmpeg.                 *
  *********************************************************/
 
-#include "private/qavdemuxer_p.h"
 #include "qavaudioframe.h"
 #include "qavvideoframe.h"
+#ifndef QTAVPLAYERLIB
+#include "private/qavdemuxer_p.h"
 #include "private/qavvideocodec_p.h"
 #include "private/qavaudiocodec_p.h"
-
+#else
+#include "qavdemuxer_p.h"
+#include "qavvideocodec_p.h"
+#include "qavaudiocodec_p.h"
+#endif
 #include <QDebug>
 #include <QtTest/QtTest>
 
@@ -74,7 +79,8 @@ void tst_QAVDemuxer::loadAudio()
 {
     QAVDemuxer d;
 
-    QFileInfo file(QLatin1String("../testdata/test.wav"));
+    auto dirName = QFileInfo(__FILE__).absoluteDir().path();
+    QFileInfo file(dirName + "/../testdata/test.wav");
 
     QVERIFY(d.load(QUrl::fromLocalFile(file.absoluteFilePath())) >= 0);
     QVERIFY(d.videoStream() < 0);
@@ -154,7 +160,8 @@ void tst_QAVDemuxer::loadVideo()
 {
     QAVDemuxer d;
 
-    QFileInfo file(QLatin1String("../testdata/colors.mp4"));
+    auto dirName = QFileInfo(__FILE__).absoluteDir().path();
+    QFileInfo file(dirName + "/../testdata/colors.mp4");
 
     QVERIFY(d.load(QUrl::fromLocalFile(file.absoluteFilePath())) >= 0);
     QVERIFY(d.videoStream() >= 0);

--- a/tests/auto/integration/qavplayer/qavplayer_lib.pro
+++ b/tests/auto/integration/qavplayer/qavplayer_lib.pro
@@ -1,0 +1,10 @@
+TARGET = tst_qavplayer
+
+QT += multimedia-private testlib
+
+include(../QtAVPlayerLib.pri)
+
+CONFIG += testcase
+
+SOURCES += \
+    tst_qavplayer.cpp

--- a/tests/auto/integration/qavplayer/tst_qavplayer.cpp
+++ b/tests/auto/integration/qavplayer/tst_qavplayer.cpp
@@ -5,7 +5,11 @@
  * Free Qt Media Player based on FFmpeg.                 *
  *********************************************************/
 
+#ifndef QTAVPLAYERLIB
 #include "qavplayer.h"
+#else
+#include <QtAVPlayer>
+#endif
 
 #include <QDebug>
 #include <QtTest/QtTest>


### PR DESCRIPTION
Taking into account it is still not clear for me how to prepare *proper* dev environment (with ability to debug & run tests) I decided to upstream my solution allowing to use QtAVPlayer as the library for qmake-based projects & specify custom FFMPEG

examples\examples_lib.pro - should build qml_video.pro & QtAVPlayer

Unfortunately I also had to deliver manually-created 'QtAVPlayer' as samples depend on it. Wondering if it can be auto-generated somehow from QtAVPlayerLib.pri / QtAVPlayerLib.pro   