### PR TITLE
Introduce accurate seek

### DIFF
--- a/src/QtAVPlayer/qavdemuxer.cpp
+++ b/src/QtAVPlayer/qavdemuxer.cpp
@@ -451,6 +451,15 @@ double QAVDemuxer::duration() const
     return d->ctx->duration * av_q2d({1, AV_TIME_BASE});
 }
 
+double QAVDemuxer::duration(int stream) const
+{
+    Q_D(const QAVDemuxer);
+    if (!d->ctx || stream < 0 || stream >= int(d->ctx->nb_streams))
+        return 0;
+
+    return d->ctx->streams[stream]->duration * av_q2d(d->ctx->streams[stream]->time_base);
+}
+
 double QAVDemuxer::frameRate() const
 {
     Q_D(const QAVDemuxer);

--- a/src/QtAVPlayer/qavdemuxer_p.h
+++ b/src/QtAVPlayer/qavdemuxer_p.h
@@ -55,6 +55,7 @@ public:
 
     QAVPacket read();
 
+    double duration(int stream) const;
     double duration() const;
     bool seekable() const;
     int seek(double sec);

--- a/src/QtAVPlayer/qavframe.cpp
+++ b/src/QtAVPlayer/qavframe.cpp
@@ -85,4 +85,13 @@ double QAVFrame::pts() const
     return d->frame->pts * av_q2d(d->codec->stream()->time_base);
 }
 
+double QAVFrame::duration() const
+{
+    Q_D(const QAVFrame);
+    if (!d->frame || !d->codec)
+        return -1;
+
+    return d->frame->pkt_duration * av_q2d(d->codec->stream()->time_base);
+}
+
 QT_END_NAMESPACE

--- a/src/QtAVPlayer/qavframe.h
+++ b/src/QtAVPlayer/qavframe.h
@@ -32,6 +32,7 @@ public:
     operator bool() const;
     AVFrame *frame() const;
     double pts() const;
+    double duration() const;
 
 protected:
     QScopedPointer<QAVFramePrivate> d_ptr;


### PR DESCRIPTION
Previously seeking returned last available frame,
now if demuxer would return frames with lower pts than requested,
all such frames will be skipped and a frame with exact requested pts should be returned.