### PR TITLE
Fix mem leak in filters

### DIFF
--- a/src/QtAVPlayer/qavaudiofilter.cpp
+++ b/src/QtAVPlayer/qavaudiofilter.cpp
@@ -71,6 +71,8 @@ int QAVAudioFilter::read(QAVFrame &frame)
         for (auto &filter: d->outputs) {
             while (true) {
                 QAVFrame out = d->sourceFrame;
+                // av_buffersink_get_frame_flags allocates frame's data
+                av_frame_unref(out.frame());
                 ret = av_buffersink_get_frame_flags(filter.ctx(), out.frame(), 0);
                 if (ret < 0)
                     break;

--- a/src/QtAVPlayer/qavvideofilter.cpp
+++ b/src/QtAVPlayer/qavvideofilter.cpp
@@ -83,6 +83,8 @@ int QAVVideoFilter::read(QAVFrame &frame)
         for (auto &filter: d->outputs) {
             while (true) {
                 QAVFrame out = d->sourceFrame;
+                // av_buffersink_get_frame_flags allocates frame's data
+                av_frame_unref(out.frame());
                 ret = av_buffersink_get_frame_flags(filter.ctx(), out.frame(), 0);
                 if (ret < 0)
                     break;


### PR DESCRIPTION
av_buffersink_get_frame_flags allocates data and prev data could be leaked.