### PR TITLE
fix QAVVideoBuffer bug

### DIFF
--- a/src/QtAVPlayer/qavvideoframe.cpp
+++ b/src/QtAVPlayer/qavvideoframe.cpp
@@ -40,8 +40,8 @@ public:
     QAVVideoFramePrivate(QAVVideoFrame *q) : q_ptr(q) { }
 
     QAVVideoBuffer &videoBuffer() const
-    {
-        if (!buffer) {
+    {       
+        if (!buffer || q_ptr->frame() != buffer->frame().frame()) {
             auto c = videoCodec(stream.codec().data());
             auto buf = c && c->device() && frame->format == c->device()->format() ? c->device()->videoBuffer(*q_ptr) : new QAVVideoBuffer_CPU(*q_ptr);
             const_cast<QAVVideoFramePrivate*>(this)->buffer.reset(buf);


### PR DESCRIPTION
QAVPacketFrameQueue::frame function call   

```
QAVSubtitleFrame &frame = static_cast<QAVSubtitleFrame &>(baseFrame); 
frame = m_frame ? static_cast<QAVSubtitleFrame &>(*m_frame) : QAVSubtitleFrame{};
```
                  
Use 
```
QAVFrame &QAVFrame::operator=(const QAVFrame &other)
{
    Q_D(QAVFrame);
    QAVStreamFrame::operator=(other);

    auto other_priv = static_cast<QAVFramePrivate *>(other.d_ptr.data());
    int64_t pts = d->frame->pts;
    av_frame_unref(d->frame);
    av_frame_ref(d->frame, other_priv->frame);

    if (d->frame->pts < 0)
        d->frame->pts = pts;

    d->frameRate = other_priv->frameRate;
    d->timeBase = other_priv->timeBase;
    return *this;
} 
```
d->frame changed but QAVVideoFrame d->buffer not destory