### PR TITLE
Read all frames after submitting a pkt

### DIFF
--- a/src/QtAVPlayer/qavdemuxer_p.h
+++ b/src/QtAVPlayer/qavdemuxer_p.h
@@ -67,7 +67,7 @@ public:
 
     QAVPacket read();
 
-    bool decode(const QAVPacket &pkt, QAVFrame &frame) const;
+    bool decode(const QAVPacket &pkt, QList<QAVFrame> &frames) const;
     bool decode(const QAVPacket &pkt, QAVSubtitleFrame &frame) const;
 
     double duration() const;

--- a/src/QtAVPlayer/qavframecodec.cpp
+++ b/src/QtAVPlayer/qavframecodec.cpp
@@ -27,17 +27,20 @@ QAVFrameCodec::QAVFrameCodec(QAVCodecPrivate &d, QObject *parent)
 {
 }
 
-bool QAVFrameCodec::decode(const AVPacket *pkt, AVFrame *frame) const
+bool QAVFrameCodec::decode(const QAVPacket &pkt, QList<QAVFrame> &frames) const
 {
     Q_D(const QAVCodec);
     if (!d->avctx)
         return false;
 
-    int ret = avcodec_send_packet(d->avctx, pkt);
+    int ret = avcodec_send_packet(d->avctx, pkt.packet());
     if (ret < 0 && ret != AVERROR(EAGAIN))
         return false;
 
-    avcodec_receive_frame(d->avctx, frame);
+    QAVFrame frame;
+    while ((ret = avcodec_receive_frame(d->avctx, frame.frame()) >= 0))
+        frames.push_back(frame);
+
     return true;
 }
 

--- a/src/QtAVPlayer/qavframecodec_p.h
+++ b/src/QtAVPlayer/qavframecodec_p.h
@@ -19,16 +19,16 @@
 // We mean it.
 //
 
+#include "qavframe.h"
 #include "qavcodec_p.h"
+#include "qavpacket_p.h"
 
 QT_BEGIN_NAMESPACE
 
-struct AVPacket;
-struct AVFrame;
 class Q_AVPLAYER_EXPORT QAVFrameCodec : public QAVCodec
 {
 public:
-    bool decode(const AVPacket *pkt, AVFrame *frame) const;
+    bool decode(const QAVPacket &pkt, QList<QAVFrame> &frames) const;
 
 protected:
     QAVFrameCodec(QObject *parent = nullptr);

--- a/src/QtAVPlayer/qavsubtitlecodec.cpp
+++ b/src/QtAVPlayer/qavsubtitlecodec.cpp
@@ -20,13 +20,16 @@ QAVSubtitleCodec::QAVSubtitleCodec(QObject *parent)
 {
 }
 
-bool QAVSubtitleCodec::decode(const AVPacket *pkt, AVSubtitle *subtitle) const
+bool QAVSubtitleCodec::decode(const QAVPacket &pkt, QAVSubtitleFrame &frame) const
 {
     Q_D(const QAVCodec);
 
     int got_output = 0;
-    int ret = avcodec_decode_subtitle2(d->avctx,
-                                       subtitle, &got_output, const_cast<AVPacket *>(pkt));
+    int ret = avcodec_decode_subtitle2(
+        d->avctx,
+        frame.subtitle(),
+        &got_output,
+        const_cast<AVPacket *>(pkt.packet()));
 
     if (ret < 0 && ret != AVERROR(EAGAIN))
         return false;

--- a/src/QtAVPlayer/qavsubtitlecodec_p.h
+++ b/src/QtAVPlayer/qavsubtitlecodec_p.h
@@ -19,7 +19,9 @@
 // We mean it.
 //
 
+#include "qavsubtitleframe.h"
 #include "qavcodec_p.h"
+#include "qavpacket_p.h"
 
 QT_BEGIN_NAMESPACE
 
@@ -30,7 +32,7 @@ class Q_AVPLAYER_EXPORT QAVSubtitleCodec : public QAVCodec
 public:
     QAVSubtitleCodec(QObject *parent = nullptr);
 
-    bool decode(const AVPacket *pkt, AVSubtitle *frame) const;
+    bool decode(const QAVPacket &pkt, QAVSubtitleFrame &frame) const;
 
 private:
     Q_DISABLE_COPY(QAVSubtitleCodec)

--- a/tests/auto/integration/qavdemuxer/tst_qavdemuxer.cpp
+++ b/tests/auto/integration/qavdemuxer/tst_qavdemuxer.cpp
@@ -53,8 +53,9 @@ void tst_QAVDemuxer::construction()
     QCOMPARE(p.duration(), 0);
     QCOMPARE(p.packet()->size, 0);
     QVERIFY(p.packet()->stream_index < 0);
-    QAVFrame f1;
-    QVERIFY(!d.decode(p, f1));
+    QList<QAVFrame> fs;
+    QVERIFY(!d.decode(p, fs));
+    QVERIFY(fs.isEmpty());
 
     QAVFrame f;
     QVERIFY(!f);
@@ -116,8 +117,10 @@ void tst_QAVDemuxer::loadAudio()
         QCOMPARE(p2.packet()->size, p.packet()->size);
         QCOMPARE(p2.packet()->stream_index, p.packet()->stream_index);
 
-        QAVFrame f;
-        QVERIFY(d.decode(p, f));
+        QList<QAVFrame> fs;
+        QVERIFY(d.decode(p, fs));
+        QCOMPARE(fs.size(), 1);
+        auto f = fs[0];
         QVERIFY(f);
         QVERIFY(f.frame());
         QVERIFY(f.pts() >= 0);
@@ -181,8 +184,10 @@ void tst_QAVDemuxer::loadVideo()
     QVERIFY(p.packet()->size > 0);
     QVERIFY(p.packet()->stream_index >= 0);
 
-    QAVFrame f;
-    QVERIFY(d.decode(p, f));
+    QList<QAVFrame> fs;
+    QVERIFY(d.decode(p, fs));
+    QCOMPARE(fs.size(), 1);
+    auto f = fs[0];
     QVERIFY(f);
     QVERIFY(f.frame());
     QVERIFY(f.pts() >= 0);
@@ -192,8 +197,10 @@ void tst_QAVDemuxer::loadVideo()
     while ((p = d.read())) {
         QCOMPARE(d.eof(), false);
         if (p.packet()->stream_index == d.currentVideoStreams().first().index()) {
-            QAVFrame f;
-            QVERIFY(d.decode(p, f));
+            QList<QAVFrame> fs1;
+            QVERIFY(d.decode(p, fs1));
+            QCOMPARE(fs1.size(), 1);
+            f = fs1[0];
             QVERIFY(f);
             QVERIFY(f.frame());
             QVERIFY(f.pts() >= 0);
@@ -236,8 +243,10 @@ void tst_QAVDemuxer::fileIO()
     QVERIFY(p.packet()->size > 0);
     QVERIFY(p.packet()->stream_index >= 0);
 
-    QAVFrame f;
-    QVERIFY(d.decode(p, f));
+    QList<QAVFrame> fs;
+    QVERIFY(d.decode(p, fs));
+    QCOMPARE(fs.size(), 1);
+    auto f = fs[0];
     QVERIFY(f);
     QVERIFY(f.frame());
     QVERIFY(f.pts() >= 0);
@@ -247,8 +256,10 @@ void tst_QAVDemuxer::fileIO()
     while ((p = d.read())) {
         QCOMPARE(d.eof(), false);
         if (p.packet()->stream_index == d.currentVideoStreams().first().index()) {
-            QAVFrame f;
-            QVERIFY(d.decode(p, f));
+            QList<QAVFrame> fs1;
+            QVERIFY(d.decode(p, fs1));
+            QCOMPARE(fs1.size(), 1);
+            f = fs1[0];
             QVERIFY(f);
             QVERIFY(f.frame());
             QVERIFY(f.pts() >= 0);
@@ -306,8 +317,10 @@ void tst_QAVDemuxer::qrcIO()
         QCOMPARE(p2.packet()->size, p.packet()->size);
         QCOMPARE(p2.packet()->stream_index, p.packet()->stream_index);
 
-        QAVFrame f;
-        QVERIFY(d.decode(p, f));
+        QList<QAVFrame> fs;
+        QVERIFY(d.decode(p, fs));
+        QCOMPARE(fs.size(), 1);
+        auto f = fs[0];
         QVERIFY(f);
         QVERIFY(f.frame());
         QVERIFY(f.pts() >= 0);


### PR DESCRIPTION
This solves issues with skipped frames for some decoders.