### PR TITLE
cppcheck++ : add missing constructors explicit.

### DIFF
--- a/src/QtAVPlayer/qavaudioframe.h
+++ b/src/QtAVPlayer/qavaudioframe.h
@@ -21,7 +21,7 @@ public:
     QAVAudioFrame();
     ~QAVAudioFrame();
     QAVAudioFrame(const QAVFrame &other);
-    QAVAudioFrame(const QAVAudioFrame &other);
+    explicit QAVAudioFrame(const QAVAudioFrame &other);
     QAVAudioFrame(const QAVAudioFormat &format, const QByteArray &data);
     QAVAudioFrame &operator=(const QAVFrame &other);
     QAVAudioFrame &operator=(const QAVAudioFrame &other);

--- a/src/QtAVPlayer/qavaudiooutput.h
+++ b/src/QtAVPlayer/qavaudiooutput.h
@@ -20,7 +20,7 @@ class QAVAudioOutputPrivate;
 class QAVAudioOutput : public QObject
 {
 public:
-    QAVAudioOutput(QObject *parent = nullptr);
+    explicit QAVAudioOutput(QObject *parent = nullptr);
     ~QAVAudioOutput();
 
     void setVolume(qreal v);

--- a/src/QtAVPlayer/qavframe.h
+++ b/src/QtAVPlayer/qavframe.h
@@ -32,7 +32,7 @@ public:
     void setFilterName(const QString &name);
 
 protected:
-    QAVFrame(QAVFramePrivate &d);
+    explicit QAVFrame(QAVFramePrivate &d);
     Q_DECLARE_PRIVATE(QAVFrame)
 };
 

--- a/src/QtAVPlayer/qavplayer.h
+++ b/src/QtAVPlayer/qavplayer.h
@@ -50,7 +50,7 @@ public:
         FilterError
     };
 
-    QAVPlayer(QObject *parent = nullptr);
+    explicit QAVPlayer(QObject *parent = nullptr);
     ~QAVPlayer();
 
     void setSource(const QString &url, const QSharedPointer<QAVIODevice> &dev = {});

--- a/src/QtAVPlayer/qavstream.h
+++ b/src/QtAVPlayer/qavstream.h
@@ -24,7 +24,7 @@ class QAVStream
 public:
     QAVStream();
     QAVStream(int index, AVFormatContext *ctx = nullptr, const QSharedPointer<QAVCodec> &codec = {});
-    QAVStream(const QAVStream &other);
+    explicit QAVStream(const QAVStream &other);
     ~QAVStream();
     QAVStream &operator=(const QAVStream &other);
     operator bool() const;

--- a/src/QtAVPlayer/qavstreamframe.h
+++ b/src/QtAVPlayer/qavstreamframe.h
@@ -19,7 +19,7 @@ class QAVStreamFrame
 {
 public:
     QAVStreamFrame();
-    QAVStreamFrame(const QAVStreamFrame &other);
+    explicit QAVStreamFrame(const QAVStreamFrame &other);
     ~QAVStreamFrame();
     QAVStreamFrame &operator=(const QAVStreamFrame &other);
 

--- a/src/QtAVPlayer/qavvideoframe.h
+++ b/src/QtAVPlayer/qavvideoframe.h
@@ -38,7 +38,7 @@ public:
 
     QAVVideoFrame();
     QAVVideoFrame(const QAVFrame &other);
-    QAVVideoFrame(const QAVVideoFrame &other);
+    explicit QAVVideoFrame(const QAVVideoFrame &other);
     QAVVideoFrame(const QSize &size, AVPixelFormat fmt);
 
     QAVVideoFrame &operator=(const QAVFrame &other);


### PR DESCRIPTION
cppcheck report missing explicit constructors. This PR fix this.