### PR TITLE
Move private impl of QAVAudioOutput to audio thread

### DIFF
--- a/src/QtAVPlayer/qavaudiooutput.cpp
+++ b/src/QtAVPlayer/qavaudiooutput.cpp
@@ -77,7 +77,7 @@ static QAudioFormat format(const QAVAudioFormat &from)
     return out;
 }
 
-class QAVAudioOutputPrivate
+class QAVAudioOutputPrivate : public QObject
 {
 public:
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
@@ -156,7 +156,7 @@ QAVAudioOutput::QAVAudioOutput(QObject *parent)
     Q_D(QAVAudioOutput);
     // The audio is rendered by this thread
     d->audioThread.reset(new QThread);
-    moveToThread(d->audioThread.get());
+    d->moveToThread(d->audioThread.get());
     // QAVAudioOutputDevice::readData() should be called on audioThread
     d->device.reset(new QAVAudioOutputDevice);
     d->device->open(QIODevice::ReadOnly);
@@ -236,7 +236,7 @@ bool QAVAudioOutput::play(const QAVAudioFrame &frame)
         quint64 bufferSize = d->bufferSize ? qMin(d->bufferSize, 96000) : 96000;
         if (d->device->bytesInQueue() >= bufferSize) {
             // Reset the output on QAVAudioOutput's thread
-            QMetaObject::invokeMethod(this, [fmt, d] {
+            QMetaObject::invokeMethod(d, [fmt, d] {
                 d->resetIfNeeded(fmt, d->bufferSize, d->volume);
             });
         }

--- a/tests/auto/integration/qavplayer/tst_qavplayer.cpp
+++ b/tests/auto/integration/qavplayer/tst_qavplayer.cpp
@@ -1868,6 +1868,11 @@ void tst_QAVPlayer::audioOutput()
         frame = f;
     }, Qt::DirectConnection);
 
+    auto outWithParent = new QAVAudioOutput(&p);
+    QObject::connect(&p, &QAVPlayer::audioFrame, &p, [&outWithParent](const QAVAudioFrame &f) {
+        outWithParent->play(f);
+    }, Qt::DirectConnection);
+
     p.setSource(file1.absoluteFilePath());
     p.play();
     QTest::qWait(100);


### PR DESCRIPTION
moveToThread() will fail if the QObject has a parent