### PR TITLE
Fix `QtAVPlayer_SOURCES` typo

### DIFF
--- a/src/QtAVPlayer/QtAVPlayer.cmake
+++ b/src/QtAVPlayer/QtAVPlayer.cmake
@@ -175,7 +175,7 @@ if(QT_AVPLAYER_VA_X11)
     )
 
     set(QtAVPlayer_SOURCES
-        ${QT_AVPLAYER_SOURCES}
+        ${QtAVPlayer_SOURCES}
         ${QT_AVPLAYER_DIR}/qavhwdevice_vaapi_x11_glx.cpp
     )
 endif()


### PR DESCRIPTION
Hello,

thank you for open-sourcing the library.

I stumbled upon a typo within the CMake file.

Best regards,
Niko Kriznik