### PR TITLE
Fix QAbstractVideoBuffer interface for Qt 6.7.2+

### DIFF
--- a/src/QtAVPlayer/qavvideoframe.cpp
+++ b/src/QtAVPlayer/qavvideoframe.cpp
@@ -229,7 +229,15 @@ public:
     {
     }
 
+#if QT_VERSION < QT_VERSION_CHECK(6, 7, 2)
+    QVideoFrame::MapMode mapMode() const override { return m_mode; }
+
     quint64 textureHandle(int plane) const override
+#else
+    QVideoFrame::MapMode mapMode() const { return m_mode; }
+
+    quint64 textureHandle(QRhi*, int plane) const override
+#endif
     {
         if (m_textures.isNull())
             const_cast<PlanarVideoBuffer *>(this)->m_textures = m_frame.handle(m_rhi);
@@ -241,7 +249,6 @@ public:
         return m_textures.toULongLong();
     }
 
-    QVideoFrame::MapMode mapMode() const override { return m_mode; }
     MapData map(QVideoFrame::MapMode mode) override
     {
         MapData res;


### PR DESCRIPTION
QAbstractVideoBuffer has changed from
```
    virtual QVideoFrame::MapMode mapMode() const = 0;
    virtual MapData map(QVideoFrame::MapMode mode) = 0;
    virtual void unmap() = 0;

    virtual std::unique_ptr<QVideoFrameTextures> mapTextures(QRhi *) { return {}; }
    virtual quint64 textureHandle(int /*plane*/) const { return 0; }

    virtual QMatrix4x4 externalTextureMatrix() const { return {}; }

    virtual QByteArray underlyingByteArray(int /*plane*/) const { return {}; }
```
in version 6.7.1 (https://github.com/qt/qtmultimedia/blob/6.7.1/src/multimedia/video/qabstractvideobuffer_p.h) to
```
    virtual MapData map(QVideoFrame::MapMode mode) = 0;
    virtual void unmap() = 0;

    virtual std::unique_ptr<QVideoFrameTextures> mapTextures(QRhi *) { return {}; }
    virtual quint64 textureHandle(QRhi *, int /*plane*/) const { return 0; }

    virtual QMatrix4x4 externalTextureMatrix() const { return {}; }
```
in version 6.7.2 (https://github.com/qt/qtmultimedia/blob/6.7.2/src/multimedia/video/qabstractvideobuffer_p.h)