### PR TITLE
[player] Fix player hanging when terminate

### DIFF
--- a/src/QtAVPlayer/qavplayer.cpp
+++ b/src/QtAVPlayer/qavplayer.cpp
@@ -329,9 +329,13 @@ void QAVPlayerPrivate::terminate()
     if (dev)
         dev->abort(true);
     loaderFuture.waitForFinished();
-    demuxerFuture.waitForFinished();
     videoPlayFuture.waitForFinished();
     audioPlayFuture.waitForFinished();
+
+    demuxer.abort();
+    demuxerFuture.waitForFinished();
+    demuxer.abort(false);
+
     pendingPosition = 0;
     pendingSeek = false;
     currPts = 0.0;


### PR DESCRIPTION
This PR is meant to fix player from hanging when demuxer terminate method is called.
More details on this issue will be find inside : https://github.com/valbok/QtAVPlayer/issues/497