### PR TITLE
Add ffmpeg debug control

### DIFF
--- a/src/QtAVPlayer/qavplayer.cpp
+++ b/src/QtAVPlayer/qavplayer.cpp
@@ -1313,6 +1313,19 @@ void QAVPlayer::setInputOptions(const QMap<QString, QString>  &opts)
     Q_EMIT inputOptionsChanged(opts);
 }
 
+
+/*!
+ * \brief Use to set log level of FFmpeg backend
+ * \param[in] level
+ * Level log to use. Please see:
+ * https://ffmpeg.org/doxygen/trunk/group__lavu__log__constants.html
+ * for value details
+ */
+void QAVPlayer::setLogsLevelBackend(int level)
+{
+    av_log_set_level(level);
+}
+
 QAVStream::Progress QAVPlayer::progress(const QAVStream &s) const
 {
     return d_func()->demuxer.progress(s);

--- a/src/QtAVPlayer/qavplayer.h
+++ b/src/QtAVPlayer/qavplayer.h
@@ -139,6 +139,9 @@ Q_SIGNALS:
     void audioFrame(const QAVAudioFrame &frame);
     void subtitleFrame(const QAVSubtitleFrame &frame);
 
+public:
+    static void setLogsLevelBackend(int level);
+    
 protected:
     std::unique_ptr<QAVPlayerPrivate> d_ptr;
 


### PR DESCRIPTION
This PR add more controls to FFmpeg log/debug management by:
- Fixing an issue where FFmpeg log callback was set "too late", resulting in some debug informations not being printed (default FFmpeg callback was used).
- Allowing to set FFmpeg log level to use (level values are available at https://ffmpeg.org/doxygen/trunk/group__lavu__log__constants.html )
