### PR TITLE
Crash on terminate when switching sources and calling `play`

### DIFF
--- a/src/QtAVPlayer/qavplayer.cpp
+++ b/src/QtAVPlayer/qavplayer.cpp
@@ -316,6 +316,16 @@ void QAVPlayerPrivate::terminate()
     setState(QAVPlayer::StoppedState);
     quit = true;
     wait(false);
+
+    if (dev)
+        dev->abort(true);
+    demuxer.abort();
+    demuxerFuture.waitForFinished();
+    loaderFuture.waitForFinished();
+    videoPlayFuture.waitForFinished();
+    audioPlayFuture.waitForFinished();
+    demuxer.abort(false);
+
     videoFrameRate = 0.0;
     videoQueue.clear();
     videoQueue.abort();
@@ -326,14 +336,6 @@ void QAVPlayerPrivate::terminate()
     subtitleQueue.clear();
     subtitleQueue.abort();
     subtitleClock.clear();
-    if (dev)
-        dev->abort(true);
-    demuxer.abort();
-    demuxerFuture.waitForFinished();
-    loaderFuture.waitForFinished();
-    videoPlayFuture.waitForFinished();
-    audioPlayFuture.waitForFinished();
-    demuxer.abort(false);
 
     pendingPosition = 0;
     pendingSeek = false;


### PR DESCRIPTION
Hi, valbok. I experienced some crashes when switching **network** sources and calling play. This crash might happen after multiple attempts.

Here is small demo:
```c
#include <QApplication>
#include <QtAVPlayer/qavaudiooutput.h>
#include <QtAVPlayer/qavplayer.h>

#include <QComboBox>
#include <QLoggingCategory>
#include <QPushButton>
#include <QVBoxLayout>
#include <QWidget>

using namespace std::chrono_literals;

int main(int argc, char *argv[]) {
  QLoggingCategory::setFilterRules("qt.QtAVPlayer.debug=true");

  QApplication app(argc, argv);

  QAVPlayer p;

  QComboBox *combo = new QComboBox;
  combo->setMaximumWidth(300);

  combo->addItem("https://s7-webradio.rockantenne.de/alternative/stream/mp3");
  combo->addItem("http://79.120.77.11:8000/punkru");
  combo->addItem("https://live.hunter.fm/rock_high");

  QWidget window;

  QPushButton *playButton = new QPushButton("Play");
  QPushButton *stopButton = new QPushButton("Stop");

  QVBoxLayout layout(&window);
  layout.addWidget(combo);
  layout.addWidget(playButton);
  layout.addWidget(stopButton);

  QAVAudioOutput *audioOutput = nullptr;

  QObject::connect(combo, &QComboBox::currentIndexChanged, &p, [&]() {
    p.stop();

    if (audioOutput) {
      audioOutput->stop();
      audioOutput->deleteLater();
    }

    audioOutput = new QAVAudioOutput(&p);
    audioOutput->setVolume(0.5);

    p.setSource(combo->currentText());
    p.play();

    // audioOutput.setBufferSize(128 * 1024);
    QObject::connect(
        &p, &QAVPlayer::audioFrame, audioOutput,
        [audioOutput](const QAVAudioFrame &frame) { audioOutput->play(frame); },
        Qt::DirectConnection);
  });

  QObject::connect(playButton, &QPushButton::clicked, &p, [&]() { p.play(); });
  QObject::connect(stopButton, &QPushButton::clicked, &p, [&]() { p.stop(); });

  window.show();

  return app.exec();
}
```

Reproduce:
1. Switch source and call play()
2. Repeat first step multiple times

Possible reason:
Functions executing in wrong order. We waiting for futures when we already deallocated some resources that futures might depend on.

If I'm wrong please correct me.