### PR TITLE
Don't accept packets if the abort is called

### DIFF
--- a/src/QtAVPlayer/qavpacketqueue_p.h
+++ b/src/QtAVPlayer/qavpacketqueue_p.h
@@ -146,11 +146,12 @@ public:
     void enqueue(const QAVPacket &packet)
     {
         QMutexLocker locker(&m_mutex);
+        if (m_abort)
+            return;
         m_packets.append(packet);
         m_bytes += packet.packet()->size + sizeof(packet);
         m_duration += packet.duration();
         m_consumerWaiter.wakeAll();
-        m_abort = false;
         m_waitingForPackets = false;
     }
 
@@ -180,10 +181,10 @@ public:
             m_producerWaiter.wait(&m_mutex);
     }
 
-    void abort()
+    void abort(bool aborted = true)
     {
         QMutexLocker locker(&m_mutex);
-        m_abort = true;
+        m_abort = aborted;
         m_waitingForPackets = true;
         m_consumerWaiter.wakeAll();
         m_producerWaiter.wakeAll();

--- a/src/QtAVPlayer/qavplayer.cpp
+++ b/src/QtAVPlayer/qavplayer.cpp
@@ -333,6 +333,9 @@ void QAVPlayerPrivate::terminate()
     loaderFuture.waitForFinished();
     videoPlayFuture.waitForFinished();
     audioPlayFuture.waitForFinished();
+    videoQueue.abort(false);
+    audioQueue.abort(false);
+    subtitleQueue.abort(false);
     demuxer.abort(false);
 
     pendingPosition = 0;

--- a/tests/auto/integration/qavplayer/tst_qavplayer.cpp
+++ b/tests/auto/integration/qavplayer/tst_qavplayer.cpp
@@ -103,6 +103,7 @@ private slots:
     void multiFilterInputs_data();
     void multiFilterInputs();
     void streamMetadataRotate();
+    void switchingSource();
 };
 
 void tst_QAVPlayer::initTestCase()
@@ -3424,6 +3425,21 @@ void tst_QAVPlayer::streamMetadataRotate()
     QVERIFY(!p.currentVideoStreams()[0].metadata().isEmpty());
     QVERIFY(p.currentVideoStreams()[0].metadata().contains("rotate"));
     QCOMPARE(p.currentVideoStreams()[0].metadata()["rotate"], "90");
+}
+
+void tst_QAVPlayer::switchingSource()
+{
+    QAVPlayer p;
+    QList<QString> files = {"av_sample.mkv", "test.mkv", "small.mp4"};
+    p.setSynced(false);
+    for (const auto &f : files) {
+        QFileInfo file(testData(f));
+        p.setSource(file.absoluteFilePath());
+        p.play();
+        QTRY_VERIFY(p.mediaStatus() == QAVPlayer::LoadedMedia || p.mediaStatus() == QAVPlayer::EndOfMedia);
+    }
+
+    QTRY_COMPARE(p.mediaStatus(), QAVPlayer::EndOfMedia);
 }
 
 QTEST_MAIN(tst_QAVPlayer)


### PR DESCRIPTION
This prevents the crash since the packet can be enqueued after the terminate is finished