### PR TITLE
Set viewPort for QVideoFrameFormat

### DIFF
--- a/src/QtAVPlayer/qavvideoframe.cpp
+++ b/src/QtAVPlayer/qavvideoframe.cpp
@@ -491,6 +491,14 @@ QAVVideoFrame::operator QVideoFrame() const
     return QVideoFrame(new PlanarVideoBuffer(result, type), size(), format);
 #else
     QVideoFrameFormat videoFormat(size(), format);
+    
+    QRect viewport(
+        frame()->crop_left,
+        frame()->crop_top,
+        frame()->width - frame()->crop_left - frame()->crop_right,
+        frame()->height - frame()->crop_top - frame()->crop_bottom
+    );
+    videoFormat.setViewport(viewport);
 #if QT_VERSION >= QT_VERSION_CHECK(6, 4, 0)
     videoFormat.setColorSpace(PlanarVideoBuffer::colorSpace(frame()));
     videoFormat.setColorTransfer(PlanarVideoBuffer::colorTransfer(frame()));


### PR DESCRIPTION
If we, for example, did not apply cropping, then for the correct display of the frame, we should set viewPort. Here is a real example of when these changes make sense:
When decoding a video stream with HW MediaCodec, the frame parameters change from 1280x720 to 1280x736 at startup. We opened an issue on ffmpeg regarding the fact that this information should be sent to us in the frame https://trac.ffmpeg.org/ticket/11317 (a patch has been prepared and I hope it will be merged soon). With their patch and apply_cropping 0, we get a frame with the following parameters at the output: width=1280 height=736 crops top=0 bottom=16 left=0 right=0, so I think it would be good to set viewPort for this case, in other cases this will not affect the stream since the crops will be zero.