### PR TITLE
Don't call VDPAUFiniNV on dtor of the frame

### DIFF
--- a/src/QtAVPlayer/qavhwdevice_vdpau.cpp
+++ b/src/QtAVPlayer/qavhwdevice_vdpau.cpp
@@ -115,7 +115,6 @@ public:
 
         if (gl_texture) {
             glDeleteTextures(1, &gl_texture);
-            s_VDPAUFiniNV();
         }
     }
 


### PR DESCRIPTION
This fixes VDPAU rendering on 6.8.2