### PR TITLE
emit QAVPlayer errorOccurred when av_read_frame returns unexpected result

### DIFF
--- a/src/QtAVPlayer/qavdemuxer_p.h
+++ b/src/QtAVPlayer/qavdemuxer_p.h
@@ -67,7 +67,6 @@ public:
     AVFormatContext *avctx() const;
 
     QAVPacket read();
-    int lastError() const;
 
     void decode(const QAVPacket &pkt, QList<QAVFrame> &frames) const;
     void decode(const QAVPacket &pkt, QList<QAVSubtitleFrame> &frames) const;

--- a/src/QtAVPlayer/qavdemuxer_p.h
+++ b/src/QtAVPlayer/qavdemuxer_p.h
@@ -65,8 +65,9 @@ public:
     bool setSubtitleStreams(const QList<QAVStream> &streams);
 
     AVFormatContext *avctx() const;
+    int read(QAVPacket &pkt);
 
-    QAVPacket read();
+    QT_DEPRECATED_X("Use read(QAVPacket &outPacket)") QAVPacket read();
 
     void decode(const QAVPacket &pkt, QList<QAVFrame> &frames) const;
     void decode(const QAVPacket &pkt, QList<QAVSubtitleFrame> &frames) const;

--- a/src/QtAVPlayer/qavplayer.cpp
+++ b/src/QtAVPlayer/qavplayer.cpp
@@ -637,10 +637,6 @@ void QAVPlayerPrivate::doDemux()
                     break;
             }
         } else {
-            if (int err = demuxer.lastError()) {
-                setError(QAVPlayer::ResourceError, QLatin1String("av_read_frame: unexpected result: ") + err_str(err));
-                return;
-            }
             if (demuxer.eof()
                 && videoQueue.isEmpty()
                 && audioQueue.isEmpty()


### PR DESCRIPTION
1. Added a lastError() accessor and internal tracking in the demuxer to capture unexpected av_read_frame results for later retrieval
2. QAVPlayer now checks lastError() after reading packets and emits errorOccurred when an unexpected result is detected

