### PR TITLE
Fix EOF handling in QAVDemuxer::read and its usage in QAVPlayer.

### DIFF
--- a/src/QtAVPlayer/qavdemuxer.cpp
+++ b/src/QtAVPlayer/qavdemuxer.cpp
@@ -698,7 +698,7 @@ int QAVDemuxer::read(QAVPacket &pkt)
     {
         QMutexLocker locker(&d->mutex);
         d->eof = eof;
-        if (ret >= 0 && pkt.packet()->stream_index < d->availableStreams.size())
+        if ((ret >= 0 || eof) && pkt.packet()->stream_index < d->availableStreams.size())
             pkt.setStream(d->availableStreams[pkt.packet()->stream_index]);
         // Allow EOF to flush BSF (send NULL)
         if ((ret >= 0 || eof) && d->bsf_ctx) {
@@ -713,9 +713,9 @@ int QAVDemuxer::read(QAVPacket &pkt)
             }
             if (!d->packets.isEmpty())
                 pkt = d->packets.takeFirst();
-            else
+            else if (!eof)
                 pkt = QAVPacket();
-        } else if (ret < 0) {
+        } else if (ret < 0 && !eof) {
             pkt = QAVPacket();
         }
     }

--- a/src/QtAVPlayer/qavdemuxer_p.h
+++ b/src/QtAVPlayer/qavdemuxer_p.h
@@ -67,7 +67,6 @@ public:
     AVFormatContext *avctx() const;
 
     QAVPacket read();
-    int lastError() const;
 
     void decode(const QAVPacket &pkt, QList<QAVFrame> &frames) const;
     void decode(const QAVPacket &pkt, QList<QAVSubtitleFrame> &frames) const;

--- a/src/QtAVPlayer/qavdemuxer_p.h
+++ b/src/QtAVPlayer/qavdemuxer_p.h
@@ -65,8 +65,9 @@ public:
     bool setSubtitleStreams(const QList<QAVStream> &streams);
 
     AVFormatContext *avctx() const;
+    int read(QAVPacket &pkt);
 
-    QAVPacket read();
+    QT_DEPRECATED_X("Use read(QAVPacket &outPacket)") QAVPacket read();
 
     void decode(const QAVPacket &pkt, QList<QAVFrame> &frames) const;
     void decode(const QAVPacket &pkt, QList<QAVSubtitleFrame> &frames) const;

--- a/src/QtAVPlayer/qavplayer.cpp
+++ b/src/QtAVPlayer/qavplayer.cpp
@@ -620,7 +620,7 @@ void QAVPlayerPrivate::doDemux()
 
         QAVPacket packet;
         int ret = demuxer.read(packet);
-        if (ret >= 0 && packet.stream()) {
+        if ((ret >= 0 && packet.stream()) || ret == AVERROR_EOF) {
             muxer.write(packet);
             endOfFile(false);
             // Empty packet points to EOF and it needs to flush codecs

--- a/src/QtAVPlayer/qavplayer.cpp
+++ b/src/QtAVPlayer/qavplayer.cpp
@@ -637,10 +637,6 @@ void QAVPlayerPrivate::doDemux()
                     break;
             }
         } else {
-            if (int err = demuxer.lastError()) {
-                setError(QAVPlayer::ResourceError, QLatin1String("av_read_frame: unexpected result: ") + err_str(err));
-                return;
-            }
             if (demuxer.eof()
                 && videoQueue.isEmpty()
                 && audioQueue.isEmpty()


### PR DESCRIPTION
## Changes
- Ensure EOF packets **retain stream info** (empty data but valid stream) instead of clearing them.
- Send `NULL` to bitstream filters on EOF to **flush buffered frames**.
- Update `QAVPlayer` to treat `AVERROR_EOF` as a valid case for flushing, not as a fatal error.
