### PR TITLE
Deliver a frame immediately If it has pts in the past

### DIFF
--- a/src/QtAVPlayer/qavpacketqueue_p.h
+++ b/src/QtAVPlayer/qavpacketqueue_p.h
@@ -70,6 +70,8 @@ public:
         delay /= speed;
         const double time = av_gettime_relative() / 1000000.0;
         if (shouldSync) {
+            if (pts < prevPts)
+                return true;
             if (time < frameTimer + delay) {
                 double remaining_time = qMin(frameTimer + delay - time, refreshRate);
                 locker.unlock();


### PR DESCRIPTION
Instead of waiting.
This is usefull when frames are synced from different sources