### PR TITLE
Don't check for the error if packet contains the stream

### DIFF
--- a/src/QtAVPlayer/qavplayer.cpp
+++ b/src/QtAVPlayer/qavplayer.cpp
@@ -626,7 +626,7 @@ void QAVPlayerPrivate::doDemux()
 
         QAVPacket packet;
         int ret = demuxer.read(packet);
-        if ((ret >= 0 || ret == AVERROR_EOF) && packet.stream()) {
+        if (packet.stream()) {
             muxer.write(packet);
             endOfFile(false);
             // Empty packet points to EOF and it needs to flush codecs


### PR DESCRIPTION
If there is a stream assigned to a packet, need to handle anyway.