### PR TITLE
Implement method of reading chapters (with metadata) from loaded media

### DIFF
--- a/examples/qml_video/main.cpp
+++ b/examples/qml_video/main.cpp
@@ -127,6 +127,18 @@ int main(int argc, char *argv[])
     QObject::connect(&p, &QAVPlayer::mediaStatusChanged, [&](auto status) {
         qDebug() << "mediaStatusChanged"<< status << p.state();
         if (status == QAVPlayer::LoadedMedia) {
+            auto chaps = p.chapters();
+            qDebug() << "Chapters:" << chaps.size();
+            for( const QVariantMap &ent : chaps ) {
+                qDebug().nospace() << "Chapter #" << ent["id"].toInt() << ":";
+                QVariantMap metadata = ent["metadata"].toMap();
+                QList<QString> metakeys = metadata.keys();
+                for( const QString &k : metakeys ) {
+                    qDebug().noquote().nospace() << "  " << k << ": \"" << metadata[k].toString() << "\"";
+                }
+                qDebug().nospace() << "  " << ent["start_time"].toDouble() << "s => " << ent["end_time"].toDouble() << "s";
+            }
+
             auto availableVideoStreams = p.availableVideoStreams();
             //p.setVideoStreams({});
             auto videoStreams = p.currentVideoStreams();

--- a/src/QtAVPlayer/qavdemuxer.cpp
+++ b/src/QtAVPlayer/qavdemuxer.cpp
@@ -835,6 +835,34 @@ QMap<QString, QString> QAVDemuxer::metadata() const
     return result;
 }
 
+QList<QVariantMap> QAVDemuxer::chapters() const
+{
+    Q_D(const QAVDemuxer);
+    QList<QVariantMap> result;
+    if (d->ctx == nullptr)
+        return result;
+
+    for (int i = 0; i < d->ctx->nb_chapters; i++) {
+        AVChapter *chapter = d->ctx->chapters[i];
+        QVariantMap ent;
+        ent["id"] = (uint)chapter->id;
+        ent["time_base"] = av_q2d(chapter->time_base);
+        ent["start"] = (qlonglong)chapter->start;
+        ent["start_time"] = chapter->start * av_q2d(chapter->time_base);
+        ent["end"] = (qlonglong)chapter->end;
+        ent["end_time"] = chapter->end * av_q2d(chapter->time_base);
+
+        AVDictionaryEntry *tag = nullptr;
+        QVariantMap metadata;
+        while ((tag = av_dict_get(chapter->metadata, "", tag, AV_DICT_IGNORE_SUFFIX)))
+            metadata[QString::fromUtf8(tag->key)] = QString::fromUtf8(tag->value);
+
+        ent["metadata"] = metadata;
+        result.push_back(ent);
+    }
+    return result;
+}
+
 QString QAVDemuxer::bitstreamFilter() const
 {
     Q_D(const QAVDemuxer);

--- a/src/QtAVPlayer/qavdemuxer_p.h
+++ b/src/QtAVPlayer/qavdemuxer_p.h
@@ -82,6 +82,7 @@ public:
     double videoFrameRate() const;
 
     QMap<QString, QString> metadata() const;
+    QList<QVariantMap> chapters() const;
 
     QString bitstreamFilter() const;
     int applyBitstreamFilter(const QString &bsfs);

--- a/src/QtAVPlayer/qavplayer.cpp
+++ b/src/QtAVPlayer/qavplayer.cpp
@@ -1419,6 +1419,11 @@ QAVStream::Progress QAVPlayer::progress(const QAVStream &s) const
     return d_func()->demuxer.progress(s);
 }
 
+QList<QVariantMap> QAVPlayer::chapters() const
+{
+    return d_func()->demuxer.chapters();
+}
+
 #ifndef QT_NO_DEBUG_STREAM
 QDebug operator<<(QDebug dbg, QAVPlayer::State state)
 {

--- a/src/QtAVPlayer/qavplayer.h
+++ b/src/QtAVPlayer/qavplayer.h
@@ -119,6 +119,8 @@ public:
 
     QAVStream::Progress progress(const QAVStream &stream) const;
 
+    QList<QVariantMap> chapters() const;
+
 public Q_SLOTS:
     void play();
     void pause();


### PR DESCRIPTION
Implemented simply as:

```
QList<QVariantMap> QAVDemuxer::chapters() const
QList<QVariantMap> QAVPlayer::chapters() const;
```

Also stores chapter metadata as QVariantMap under the "metadata" key. Timestamps converted to double.