### PR TITLE
Introduce 'software' video codec  to force software decoding

### DIFF
--- a/examples/qml_video/main.cpp
+++ b/examples/qml_video/main.cpp
@@ -193,8 +193,11 @@ int main(int argc, char *argv[])
     }
     p.setSource(file, qrc);
     p.setFilter(filter);
+    // Force software decoding
+    //p.setInputVideoCodec(QString::fromLatin1("software"));
     if (filter.isEmpty())
         p.setOutput(output);
+    // Disable syncing frames using their pts
     //p.setSynced(false);
 
     viewer.setMinimumSize(QSize(300, 360));

--- a/src/QtAVPlayer/qavdemuxer.cpp
+++ b/src/QtAVPlayer/qavdemuxer.cpp
@@ -184,13 +184,19 @@ void QAVDemuxer::abort(bool stop)
 
 static int setup_video_codec(const QString &inputVideoCodec, AVStream *stream, QAVVideoCodec &codec, AVDictionary **codecOpts)
 {
+    bool ignoreHW = qEnvironmentVariableIsSet("QT_AVPLAYER_NO_HWDEVICE");
     const AVCodec *videoCodec = nullptr;
     if (!inputVideoCodec.isEmpty()) {
-        qDebug() << "Loading: -vcodec" << inputVideoCodec;
-        videoCodec = avcodec_find_decoder_by_name(inputVideoCodec.toUtf8().constData());
-        if (!videoCodec) {
-            qWarning() << "Could not find decoder:" << inputVideoCodec;
-            return AVERROR(EINVAL);
+        if (inputVideoCodec == QLatin1String("software")) {
+            qDebug() << "Ignore hardware device context";
+            ignoreHW = true;
+        } else {
+            qDebug() << "Loading: -vcodec" << inputVideoCodec;
+            videoCodec = avcodec_find_decoder_by_name(inputVideoCodec.toUtf8().constData());
+            if (!videoCodec) {
+                qWarning() << "Could not find decoder:" << inputVideoCodec;
+                return AVERROR(EINVAL);
+            }
         }
     }
 
@@ -200,7 +206,6 @@ static int setup_video_codec(const QString &inputVideoCodec, AVStream *stream, Q
     QList<QSharedPointer<QAVHWDevice>> devices;
     QAVDictionaryHolder opts;
     Q_UNUSED(opts);
-    static const bool ignoreHW = qEnvironmentVariableIsSet("QT_AVPLAYER_NO_HWDEVICE");
 
 #if defined(QT_AVPLAYER_VA_X11) && QT_CONFIG(opengl)
     devices.append(QSharedPointer<QAVHWDevice>(new QAVHWDevice_VAAPI_X11_GLX));

--- a/src/QtAVPlayer/qavplayer.h
+++ b/src/QtAVPlayer/qavplayer.h
@@ -107,6 +107,12 @@ public:
     QString inputFormat() const;
     void setInputFormat(const QString &format);
 
+    /**
+     * Name of AVCodec to be used for video codec: `ffmpeg -vcodec h264`.
+     * It calls avcodec_find_decoder_by_name() internally.
+     * If `software` is passed, then it forces software decoding,
+     * the same as `QT_AVPLAYER_NO_HWDEVICE` env variable.
+     */
     QString inputVideoCodec() const;
     void setInputVideoCodec(const QString &codec);
     static QStringList supportedVideoCodecs();

--- a/tests/auto/integration/qavdemuxer/tst_qavdemuxer.cpp
+++ b/tests/auto/integration/qavdemuxer/tst_qavdemuxer.cpp
@@ -439,6 +439,9 @@ void tst_QAVDemuxer::videoCodecs()
     d.unload();
     d.setInputVideoCodec("unknown");
     QVERIFY(d.load(file.absoluteFilePath()) < 0);
+    d.unload();
+    d.setInputVideoCodec("software");
+    QVERIFY(d.load(file.absoluteFilePath()) >= 0);
 }
 
 void tst_QAVDemuxer::inputOptions()


### PR DESCRIPTION
Together with `QT_AVPLAYER_NO_HWDEVICE` it could force software decoding. But now possible to use it per player.