### PR TITLE
Don't use platform video buffer if the frame is already mapped

### DIFF
--- a/src/QtAVPlayer/qavdemuxer.cpp
+++ b/src/QtAVPlayer/qavdemuxer.cpp
@@ -188,7 +188,7 @@ static int setup_video_codec(const QString &inputVideoCodec, AVStream *stream, Q
     const AVCodec *videoCodec = nullptr;
     if (!inputVideoCodec.isEmpty()) {
         if (inputVideoCodec == QLatin1String("software")) {
-            qDebug() << "Ignore hardware device context";
+            qDebug() << "Video codec:" << inputVideoCodec <<", ignoring hardware device context";
             ignoreHW = true;
         } else {
             qDebug() << "Loading: -vcodec" << inputVideoCodec;

--- a/src/QtAVPlayer/qavvideoframe.cpp
+++ b/src/QtAVPlayer/qavvideoframe.cpp
@@ -256,6 +256,9 @@ public:
     #endif // QT_VERSION < QT_VERSION_CHECK(6, 8, 2)
 #endif // #if QT_VERSION < QT_VERSION_CHECK(6, 7, 2)
     {
+        // Don't use video buffer if already mapped
+        if (m_mode != QVideoFrame::NotMapped)
+            return 0;
         if (m_textures.isNull())
             const_cast<PlanarVideoBuffer *>(this)->m_textures = m_frame.handle(m_rhi);
         if (m_textures.canConvert<QList<QVariant>>()) {


### PR DESCRIPTION
It allows to avoid using handles from internal video buffer when the `QVideoFrame`  is rendered. It will use mapped data instead.