### PR TITLE
Recreate audio sink if the format has been changed

### DIFF
--- a/src/QtAVPlayer/qavaudiooutput.cpp
+++ b/src/QtAVPlayer/qavaudiooutput.cpp
@@ -101,6 +101,7 @@ public:
     std::unique_ptr<QAVAudioOutputDevice> device;
     std::unique_ptr<QThread> audioThread;
     AudioDevice defaultAudioDevice;
+    QAudioFormat audioOutputFormat;
     mutable QMutex mutex;
 
     void resetIfNeeded(const QAudioFormat &fmt, int bsize, qreal v)
@@ -144,6 +145,10 @@ public:
             audioOutput->setVolume(v);
             // Start sending the audio frames from the queue to render
             device->start();
+            audioOutputFormat = fmt;
+            locker.unlock();
+            // Start the output without the lock to allow to add frames to the device.
+            // This could wait for frames available.
             audioOutput->start(device.get());
         }
     }
@@ -233,14 +238,21 @@ bool QAVAudioOutput::play(const QAVAudioFrame &frame)
 #endif
     if (QThread::currentThread() == d->audioThread.get()) {
         qCritical() << "QAVAudioOutput::play() must not be called on the audio thread";
-    } else {
-        quint64 bufferSize = d->bufferSize ? qMin(d->bufferSize, 96000) : 96000;
-        if (d->device->bytesInQueue() >= bufferSize) {
-            // Reset the output on QAVAudioOutput's thread
-            QMetaObject::invokeMethod(d, [fmt, d] {
-                d->resetIfNeeded(fmt, d->bufferSize, d->volume);
-            });
-        }
+        return false;
+    }
+    bool reset = false;
+    {
+        QMutexLocker locker(&d->mutex);
+        // Check if the format has been changed or not yet initialized
+        reset = d->audioOutputFormat != fmt;
+    }
+    if (reset) {
+        d->device->stop();
+        // Reset the output on QAVAudioOutput's thread
+        QMetaObject::invokeMethod(d, [fmt, d] {
+            d->resetIfNeeded(fmt, d->bufferSize, d->volume);
+        });
+        return false;
     }
     // Add frames on current thread
     d->device->play(frame);

--- a/src/QtAVPlayer/qavaudiooutputdevice.cpp
+++ b/src/QtAVPlayer/qavaudiooutputdevice.cpp
@@ -101,6 +101,8 @@ void QAVAudioOutputDevice::stop()
     {
         QMutexLocker locker(&d->mutex);
         d->quit = true;
+        d->frames.clear();
+        d->offset = 0;
     }
     d->cond.wakeAll();
 }


### PR DESCRIPTION
When changing current audio stream, it is possible that the frames will be in different format. If these frames are sent to old audio sink it will produce the noise. 
It requires to restart the audio sink with correct format.

The audio output must be recreated on dedicated thread.
Tested on Linux, Windows, MacOS.