### PR TITLE
Don't recreate vdpau mixer on each frame

### DIFF
--- a/src/QtAVPlayer/qavhwdevice_vdpau.cpp
+++ b/src/QtAVPlayer/qavhwdevice_vdpau.cpp
@@ -1,9 +1,9 @@
-/*********************************************************
- * Copyright (C) 2020, Val Doroshchuk <valbok@gmail.com> *
- *                                                       *
- * This file is part of QtAVPlayer.                      *
- * Free Qt Media Player based on FFmpeg.                 *
- *********************************************************/
+/***************************************************************
+ * Copyright (C) 2020, 2026, Val Doroshchuk <valbok@gmail.com> *
+ *                                                             *
+ * This file is part of QtAVPlayer.                            *
+ * Free Qt Media Player based on FFmpeg.                       *
+ ***************************************************************/
 
 #include "qavhwdevice_vdpau_p.h"
 #include "qavvideocodec_p.h"

--- a/src/QtAVPlayer/qavhwdevice_vdpau.cpp
+++ b/src/QtAVPlayer/qavhwdevice_vdpau.cpp
@@ -51,7 +51,43 @@ static VdpVideoMixerRender *s_video_mixer_render = nullptr;
 
 QT_BEGIN_NAMESPACE
 
+class QAVHWDevice_VDPAUPrivate
+{
+public:
+    QAVHWDevice_VDPAUPrivate()
+    {
+        if (!s_VDPAUInitNV) {
+            s_VDPAUInitNV = (VDPAUInitNV_) glXGetProcAddressARB((const GLubyte *)"VDPAUInitNV");
+            s_VDPAUFiniNV = (VDPAUFiniNV_) glXGetProcAddressARB((const GLubyte *)"VDPAUFiniNV");
+            s_VDPAURegisterOutputSurfaceNV = (VDPAURegisterOutputSurfaceNV_) glXGetProcAddressARB((const GLubyte *)"VDPAURegisterOutputSurfaceNV");
+            s_VDPAUSurfaceAccessNV = (VDPAUSurfaceAccessNV_) glXGetProcAddressARB((const GLubyte *)"VDPAUSurfaceAccessNV");
+            s_VDPAUMapSurfacesNV = (VDPAUMapSurfacesNV_) glXGetProcAddressARB((const GLubyte *)"VDPAUMapSurfacesNV");
+            s_VDPAUUnmapSurfacesNV = (VDPAUUnmapSurfacesNV_) glXGetProcAddressARB((const GLubyte *)"VDPAUUnmapSurfacesNV");
+            s_VDPAUUnregisterSurfaceNV = (VDPAUUnregisterSurfaceNV_) glXGetProcAddressARB((const GLubyte *)"VDPAUUnregisterSurfaceNV");
+        }
+
+        for (int n = 0; n < MP_VDP_HISTORY_FRAMES; ++n)
+            past[n] = future[n] = VDP_INVALID_HANDLE;
+    }
+
+    ~QAVHWDevice_VDPAUPrivate()
+    {
+        if (vdp_surface != VDP_INVALID_HANDLE)
+            s_output_surface_destroy(vdp_surface);
+
+        if (video_mixer != VDP_INVALID_HANDLE)
+            s_video_mixer_destroy(video_mixer);
+    }
+
+    VdpOutputSurface vdp_surface = VDP_INVALID_HANDLE;
+    VdpVideoMixer video_mixer = VDP_INVALID_HANDLE;
+    VdpVideoSurface past[MP_VDP_HISTORY_FRAMES];
+    VdpVideoSurface future[MP_VDP_HISTORY_FRAMES];
+    VdpVideoMixerPictureStructure field = VDP_VIDEO_MIXER_PICTURE_STRUCTURE_FRAME;
+};
+
 QAVHWDevice_VDPAU::QAVHWDevice_VDPAU()
+    : d_ptr(new QAVHWDevice_VDPAUPrivate)
 {
 }
 
@@ -83,21 +119,9 @@ static int get_proc_address(AVVDPAUDeviceContext *vactx, VdpFuncId funcid, T &ou
 class VideoBuffer_VDPAU_GLX : public QAVVideoBuffer_GPU
 {
 public:
-    VideoBuffer_VDPAU_GLX(const QAVVideoFrame &frame)
-        : QAVVideoBuffer_GPU(frame)
+    VideoBuffer_VDPAU_GLX(const QAVVideoFrame &frame, QAVHWDevice_VDPAUPrivate *d)
+        : QAVVideoBuffer_GPU(frame), d(d)
     {
-        if (!s_VDPAUInitNV) {
-            s_VDPAUInitNV = (VDPAUInitNV_) glXGetProcAddressARB((const GLubyte *)"VDPAUInitNV");
-            s_VDPAUFiniNV = (VDPAUFiniNV_) glXGetProcAddressARB((const GLubyte *)"VDPAUFiniNV");
-            s_VDPAURegisterOutputSurfaceNV = (VDPAURegisterOutputSurfaceNV_) glXGetProcAddressARB((const GLubyte *)"VDPAURegisterOutputSurfaceNV");
-            s_VDPAUSurfaceAccessNV = (VDPAUSurfaceAccessNV_) glXGetProcAddressARB((const GLubyte *)"VDPAUSurfaceAccessNV");
-            s_VDPAUMapSurfacesNV = (VDPAUMapSurfacesNV_) glXGetProcAddressARB((const GLubyte *)"VDPAUMapSurfacesNV");
-            s_VDPAUUnmapSurfacesNV = (VDPAUUnmapSurfacesNV_) glXGetProcAddressARB((const GLubyte *)"VDPAUUnmapSurfacesNV");
-            s_VDPAUUnregisterSurfaceNV = (VDPAUUnregisterSurfaceNV_) glXGetProcAddressARB((const GLubyte *)"VDPAUUnregisterSurfaceNV");
-        }
-
-        for (int n = 0; n < MP_VDP_HISTORY_FRAMES; ++n)
-            past[n] = future[n] = VDP_INVALID_HANDLE;
     }
 
     ~VideoBuffer_VDPAU_GLX()
@@ -107,15 +131,8 @@ public:
             s_VDPAUUnregisterSurfaceNV(vdpgl_surface);
         }
 
-        if (vdp_surface != VDP_INVALID_HANDLE)
-            s_output_surface_destroy(vdp_surface);
-
-        if (video_mixer != VDP_INVALID_HANDLE)
-            s_video_mixer_destroy(video_mixer);
-
-        if (gl_texture) {
+        if (gl_texture)
             glDeleteTextures(1, &gl_texture);
-        }
     }
 
     QAVVideoFrame::HandleType handleType() const override
@@ -145,40 +162,54 @@ public:
         VdpVideoSurface surf = (VdpVideoSurface)(uintptr_t)av_frame->data[3];
 
         if (!gl_texture) {
-            if (!s_output_surface_create) {
-                get_proc_address(vactx, VDP_FUNC_ID_OUTPUT_SURFACE_CREATE, s_output_surface_create);
-                get_proc_address(vactx, VDP_FUNC_ID_OUTPUT_SURFACE_DESTROY, s_output_surface_destroy);
-                get_proc_address(vactx, VDP_FUNC_ID_VIDEO_MIXER_CREATE, s_video_mixer_create);
-                get_proc_address(vactx, VDP_FUNC_ID_VIDEO_MIXER_DESTROY, s_video_mixer_destroy);
-                get_proc_address(vactx, VDP_FUNC_ID_VIDEO_SURFACE_GET_PARAMETERS, s_video_surface_get_parameters);
-                get_proc_address(vactx, VDP_FUNC_ID_VIDEO_MIXER_RENDER, s_video_mixer_render);
-                get_proc_address(vactx, VDP_FUNC_ID_VIDEO_MIXER_RENDER, s_video_mixer_render);
+            if (d->video_mixer == VDP_INVALID_HANDLE) {
+                if (!s_output_surface_create) {
+                    get_proc_address(vactx, VDP_FUNC_ID_OUTPUT_SURFACE_CREATE, s_output_surface_create);
+                    get_proc_address(vactx, VDP_FUNC_ID_OUTPUT_SURFACE_DESTROY, s_output_surface_destroy);
+                    get_proc_address(vactx, VDP_FUNC_ID_VIDEO_MIXER_CREATE, s_video_mixer_create);
+                    get_proc_address(vactx, VDP_FUNC_ID_VIDEO_MIXER_DESTROY, s_video_mixer_destroy);
+                    get_proc_address(vactx, VDP_FUNC_ID_VIDEO_SURFACE_GET_PARAMETERS, s_video_surface_get_parameters);
+                    get_proc_address(vactx, VDP_FUNC_ID_VIDEO_MIXER_RENDER, s_video_mixer_render);
+                    get_proc_address(vactx, VDP_FUNC_ID_VIDEO_MIXER_RENDER, s_video_mixer_render);
+                }
+
+                VdpVideoMixerFeature features[MAX_NUM_FEATURES];
+                static const VdpVideoMixerParameter parameters[VDP_NUM_MIXER_PARAMETER] = {
+                    VDP_VIDEO_MIXER_PARAMETER_VIDEO_SURFACE_WIDTH,
+                    VDP_VIDEO_MIXER_PARAMETER_VIDEO_SURFACE_HEIGHT,
+                    VDP_VIDEO_MIXER_PARAMETER_CHROMA_TYPE,
+                };
+
+                VdpChromaType chroma_type;
+                uint32_t s_w, s_h;
+
+                s_video_surface_get_parameters(surf, &chroma_type, &s_w, &s_h);
+                const void *const parameter_values[VDP_NUM_MIXER_PARAMETER] = {
+                    &s_w,
+                    &s_h,
+                    &chroma_type,
+                };
+
+                s_video_mixer_create(vactx->device, 0, features,
+                                     VDP_NUM_MIXER_PARAMETER,
+                                     parameters, parameter_values,
+                                     &d->video_mixer);
+                s_output_surface_create(vactx->device,
+                                        VDP_RGBA_FORMAT_B8G8R8A8,
+                                        s_w,
+                                        s_h,
+                                        &d->vdp_surface);
+                s_VDPAUFiniNV();
+                auto err = glGetError();
+                if (err != GL_NO_ERROR && err != GL_INVALID_OPERATION && err != GL_INVALID_VALUE)
+                    qWarning() << "s_VDPAUFiniNV failed:" << err;
+                s_VDPAUInitNV(reinterpret_cast<const GLvoid *>(vactx->device), (const GLvoid *)vactx->get_proc_address);
+                err = glGetError();
+                if (err != GL_NO_ERROR)
+                    qWarning() << "VDPAUInitNV failed:" << err;
             }
 
-            VdpVideoMixerFeature features[MAX_NUM_FEATURES];
-            static const VdpVideoMixerParameter parameters[VDP_NUM_MIXER_PARAMETER] = {
-                VDP_VIDEO_MIXER_PARAMETER_VIDEO_SURFACE_WIDTH,
-                VDP_VIDEO_MIXER_PARAMETER_VIDEO_SURFACE_HEIGHT,
-                VDP_VIDEO_MIXER_PARAMETER_CHROMA_TYPE,
-            };
-
-            VdpChromaType chroma_type;
-            uint32_t s_w, s_h;
-
-            s_video_surface_get_parameters(surf, &chroma_type, &s_w, &s_h);
-            const void *const parameter_values[VDP_NUM_MIXER_PARAMETER] = {
-                &s_w,
-                &s_h,
-                &chroma_type,
-            };
-
-            s_video_mixer_create(vactx->device, 0, features,
-                                 VDP_NUM_MIXER_PARAMETER,
-                                 parameters, parameter_values,
-                                 &video_mixer);
-
             glGenTextures(1, &gl_texture);
-            s_VDPAUInitNV(reinterpret_cast<const GLvoid *>(vactx->device), (const GLvoid *)vactx->get_proc_address);
             glBindTexture(GL_TEXTURE_2D, gl_texture);
             glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
             glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
@@ -186,27 +217,20 @@ public:
             glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
             glBindTexture(GL_TEXTURE_2D, 0);
 
-            s_output_surface_create(vactx->device,
-                                    VDP_RGBA_FORMAT_B8G8R8A8,
-                                    s_w,
-                                    s_h,
-                                    &vdp_surface);
-
-            vdpgl_surface = s_VDPAURegisterOutputSurfaceNV(reinterpret_cast<GLvoid *>(vdp_surface),
+            vdpgl_surface = s_VDPAURegisterOutputSurfaceNV(reinterpret_cast<GLvoid *>(d->vdp_surface),
                                                            GL_TEXTURE_2D,
                                                            1, &gl_texture);
-
             s_VDPAUSurfaceAccessNV(vdpgl_surface, GL_READ_ONLY);
         }
 
         VdpRect video_rect = {0, 0, static_cast<uint32_t>(w), static_cast<uint32_t>(h)};
-        s_video_mixer_render(video_mixer, VDP_INVALID_HANDLE,
-                             0, field,
-                             MP_VDP_HISTORY_FRAMES, past,
+        s_video_mixer_render(d->video_mixer, VDP_INVALID_HANDLE,
+                             0, d->field,
+                             MP_VDP_HISTORY_FRAMES, d->past,
                              surf,
-                             MP_VDP_HISTORY_FRAMES, future,
+                             MP_VDP_HISTORY_FRAMES, d->future,
                              &video_rect,
-                             vdp_surface, NULL, NULL,
+                             d->vdp_surface, NULL, NULL,
                              0, NULL);
         s_VDPAUMapSurfacesNV(1, &vdpgl_surface);
         return gl_texture;
@@ -217,18 +241,14 @@ public:
         return const_cast<VideoBuffer_VDPAU_GLX *>(this)->texture();
     }
 
+    QAVHWDevice_VDPAUPrivate *d = nullptr;
     GLuint gl_texture = 0;
-    VdpOutputSurface vdp_surface = VDP_INVALID_HANDLE;
     GLvdpauSurfaceNV vdpgl_surface = 0;
-    VdpVideoMixer video_mixer = VDP_INVALID_HANDLE;
-    VdpVideoSurface past[MP_VDP_HISTORY_FRAMES];
-    VdpVideoSurface future[MP_VDP_HISTORY_FRAMES];
-    VdpVideoMixerPictureStructure field = VDP_VIDEO_MIXER_PICTURE_STRUCTURE_FRAME;
 };
 
 QAVVideoBuffer *QAVHWDevice_VDPAU::videoBuffer(const QAVVideoFrame &frame) const
 {
-    return new VideoBuffer_VDPAU_GLX(frame);
+    return new VideoBuffer_VDPAU_GLX(frame, d_ptr.get());
 }
 
 QT_END_NAMESPACE

--- a/src/QtAVPlayer/qavhwdevice_vdpau_p.h
+++ b/src/QtAVPlayer/qavhwdevice_vdpau_p.h
@@ -1,9 +1,9 @@
-/*********************************************************
- * Copyright (C) 2020, Val Doroshchuk <valbok@gmail.com> *
- *                                                       *
- * This file is part of QtAVPlayer.                      *
- * Free Qt Media Player based on FFmpeg.                 *
- *********************************************************/
+/***************************************************************
+ * Copyright (C) 2020, 2026, Val Doroshchuk <valbok@gmail.com> *
+ *                                                             *
+ * This file is part of QtAVPlayer.                            *
+ * Free Qt Media Player based on FFmpeg.                       *
+ ***************************************************************/
 
 #ifndef QAVHWDEVICE_VDPAU_P_H
 #define QAVHWDEVICE_VDPAU_P_H

--- a/src/QtAVPlayer/qavhwdevice_vdpau_p.h
+++ b/src/QtAVPlayer/qavhwdevice_vdpau_p.h
@@ -23,6 +23,7 @@
 
 QT_BEGIN_NAMESPACE
 
+class QAVHWDevice_VDPAUPrivate;
 class Q_AVPLAYER_EXPORT QAVHWDevice_VDPAU : public QAVHWDevice
 {
 public:
@@ -34,6 +35,7 @@ public:
     QAVVideoBuffer *videoBuffer(const QAVVideoFrame &frame) const override;
 
 private:
+    std::unique_ptr<QAVHWDevice_VDPAUPrivate> d_ptr;
     Q_DISABLE_COPY(QAVHWDevice_VDPAU)
 };
 


### PR DESCRIPTION
This fixed consuming CPU to re-create surfaces and muxers on each frame. 
Also fixed the issue when the vdpau device has been changed, this allows to start new video.