### PR TITLE
Convert int24 frames in QAVAudioConverter

### DIFF
--- a/src/QtAVPlayer/qavaudiocodec.cpp
+++ b/src/QtAVPlayer/qavaudiocodec.cpp
@@ -1,5 +1,5 @@
 /***************************************************************
- * Copyright (C) 2020, 2025, Val Doroshchuk <valbok@gmail.com> *
+ * Copyright (C) 2020, 2026, Val Doroshchuk <valbok@gmail.com> *
  *                                                             *
  * This file is part of QtAVPlayer.                            *
  * Free Qt Media Player based on FFmpeg.                       *
@@ -28,14 +28,25 @@ QAVAudioFormat QAVAudioCodec::audioFormat() const
         return format;
 
     auto fmt = AVSampleFormat(d->avctx->sample_fmt);
-    if (fmt == AV_SAMPLE_FMT_U8)
+    switch (fmt) {
+    case AV_SAMPLE_FMT_U8:
         format.setSampleFormat(QAVAudioFormat::UInt8);
-    else if (fmt == AV_SAMPLE_FMT_S16)
+        break;
+    case AV_SAMPLE_FMT_S16:
         format.setSampleFormat(QAVAudioFormat::Int16);
-    else if (fmt == AV_SAMPLE_FMT_S32)
+        break;
+    case AV_SAMPLE_FMT_S32:
         format.setSampleFormat(QAVAudioFormat::Int32);
-    else if (fmt == AV_SAMPLE_FMT_FLT)
+        break;
+    case AV_SAMPLE_FMT_FLTP:
+    case AV_SAMPLE_FMT_FLT:
+    case AV_SAMPLE_FMT_DBL:
+    case AV_SAMPLE_FMT_DBLP:
         format.setSampleFormat(QAVAudioFormat::Float);
+        break;
+    default:
+        break;
+    }
 
     format.setSampleRate(d->avctx->sample_rate);
 #if LIBAVCODEC_VERSION_INT <= AV_VERSION_INT(59, 23, 0)

--- a/src/QtAVPlayer/qavaudioconverter.cpp
+++ b/src/QtAVPlayer/qavaudioconverter.cpp
@@ -1,15 +1,17 @@
-/*********************************************************
- * Copyright (C) 2024, Val Doroshchuk <valbok@gmail.com> *
- *                                                       *
- * This file is part of QtAVPlayer.                      *
- * Free Qt Media Player based on FFmpeg.                 *
- *********************************************************/
+/***************************************************************
+ * Copyright (C) 2020, 2026, Val Doroshchuk <valbok@gmail.com> *
+ *                                                             *
+ * This file is part of QtAVPlayer.                            *
+ * Free Qt Media Player based on FFmpeg.                       *
+ ***************************************************************/
 
 #include "qavaudioconverter.h"
+#include "qavcodec_p.h"
 #include <QDebug>
 
 extern "C" {
-#include "libswresample/swresample.h"
+#include <libswresample/swresample.h>
+#include <libavcodec/avcodec.h>
 }
 
 QT_BEGIN_NAMESPACE
@@ -86,6 +88,12 @@ QByteArray QAVAudioConverter::data(const QAVAudioFrame &audioFrame)
     AVChannelLayout channelLayout = frame->ch_layout;
     bool needsConvert = frame->format != outFormat || av_channel_layout_compare(&channelLayout, &outChannelLayout) || frame->sample_rate != outSampleRate;
 #endif
+
+    // Convert int24 bit frames even if format is AV_SAMPLE_FMT_S32
+    auto codec = audioFrame.stream().codec();
+    if (codec && codec->codec() && codec->codec()->id == AV_CODEC_ID_PCM_S24BE) {
+        needsConvert = true;
+    }
 
     if (needsConvert) {
         bool needsCtxChange = outFormat != d->outFormat || outSampleRate != d->outSampleRate ||

--- a/src/QtAVPlayer/qavaudioframe.cpp
+++ b/src/QtAVPlayer/qavaudioframe.cpp
@@ -1,9 +1,9 @@
-/*********************************************************
- * Copyright (C) 2020, Val Doroshchuk <valbok@gmail.com> *
- *                                                       *
- * This file is part of QtAVPlayer.                      *
- * Free Qt Media Player based on FFmpeg.                 *
- *********************************************************/
+/***************************************************************
+ * Copyright (C) 2020, 2026, Val Doroshchuk <valbok@gmail.com> *
+ *                                                             *
+ * This file is part of QtAVPlayer.                            *
+ * Free Qt Media Player based on FFmpeg.                       *
+ ***************************************************************/
 
 #include "qavaudioframe.h"
 #include "qavaudioconverter.h"
@@ -89,11 +89,7 @@ QAVAudioFormat QAVAudioFrame::format() const
     if (!c)
         return {};
 
-    auto format = c->audioFormat();
-    if (format.sampleFormat() != QAVAudioFormat::Int32)
-        format.setSampleFormat(QAVAudioFormat::Int32);
-
-    return format;
+    return c->audioFormat();
 }
 
 QByteArray QAVAudioFrame::data() const

--- a/tests/auto/integration/qavdemuxer/tst_qavdemuxer.cpp
+++ b/tests/auto/integration/qavdemuxer/tst_qavdemuxer.cpp
@@ -161,7 +161,7 @@ void tst_QAVDemuxer::loadAudio()
         QVERIFY(af.stream().codec()->codec() != nullptr);
 
         auto format = af.format();
-        QCOMPARE(format.sampleFormat(), QAVAudioFormat::Int32);
+        QCOMPARE(format.sampleFormat(), QAVAudioFormat::Int16);
         auto data = af.data();
         QVERIFY(!data.isEmpty());
 
@@ -363,7 +363,7 @@ void tst_QAVDemuxer::qrcIO()
         QVERIFY(af.stream().codec()->codec() != nullptr);
 
         auto format = af.format();
-        QCOMPARE(format.sampleFormat(), QAVAudioFormat::Int32);
+        QCOMPARE(format.sampleFormat(), QAVAudioFormat::Int16);
         auto data = af.data();
         QVERIFY(!data.isEmpty());
 

--- a/tests/auto/integration/qavplayer/tst_qavplayer.cpp
+++ b/tests/auto/integration/qavplayer/tst_qavplayer.cpp
@@ -307,7 +307,7 @@ void tst_QAVPlayer::playAudioOutput()
 
     QTRY_VERIFY(p.position() != 0);
     QTRY_VERIFY(frame);
-    QCOMPARE(frame.format().sampleFormat(), QAVAudioFormat::Int32);
+    QCOMPARE(frame.format().sampleFormat(), QAVAudioFormat::Int16);
 
     QTRY_COMPARE(p.mediaStatus(), QAVPlayer::EndOfMedia);
     QTRY_COMPARE(p.state(), QAVPlayer::StoppedState);


### PR DESCRIPTION
If `AV_CODEC_ID_PCM_S24BE` is used, it returns frames in 24 bits pixel formats in  `AV_SAMPLE_FMT_S32`. This introduces scratching while playing.
Added explicit converting such frames to `AV_SAMPLE_FMT_S32`.