### PR TITLE
Introduce shared QAVFormatContext

### DIFF
--- a/src/QtAVPlayer/QtAVPlayer.cmake
+++ b/src/QtAVPlayer/QtAVPlayer.cmake
@@ -56,6 +56,7 @@ set(QtAVPlayer_PRIVATE_HEADERS
     ${QT_AVPLAYER_DIR}/qavaudiooutputfilter_p.h
     ${QT_AVPLAYER_DIR}/qavfilters_p.h
     ${QT_AVPLAYER_DIR}/qavaudioconverter_p.h
+    ${QT_AVPLAYER_DIR}/qavformatcontext_p.h
 )
 
 set(QtAVPlayer_PUBLIC_HEADERS
@@ -103,6 +104,7 @@ set(QtAVPlayer_SOURCES
     ${QT_AVPLAYER_DIR}/qavstream.cpp
     ${QT_AVPLAYER_DIR}/qavfilters.cpp
     ${QT_AVPLAYER_DIR}/qavaudioconverter.cpp
+    ${QT_AVPLAYER_DIR}/qavformatcontext.cpp
 )
 
 if(WIN32)

--- a/src/QtAVPlayer/QtAVPlayer.pri
+++ b/src/QtAVPlayer/QtAVPlayer.pri
@@ -29,8 +29,9 @@ PRIVATE_HEADERS += \
     $$PWD/qavaudioinputfilter_p.h \ 
     $$PWD/qavvideooutputfilter_p.h \
     $$PWD/qavaudiooutputfilter_p.h \
-    $$PWD/qavfilters_p.h
+    $$PWD/qavfilters_p.h \
     $$PWD/qavaudioconverter_p.h \
+    $$PWD/qavformatcontext_p.h \
 
 PUBLIC_HEADERS += \
     $$PWD/qaviodevice.h \
@@ -76,6 +77,7 @@ SOURCES += \
     $$PWD/qavstream.cpp \
     $$PWD/qavfilters.cpp \
     $$PWD/qavaudioconverter.cpp \
+    $$PWD/qavformatcontext.cpp \
 
 contains(DEFINES, QT_AVPLAYER_MULTIMEDIA) {
     QT += multimedia

--- a/src/QtAVPlayer/qavdemuxer.cpp
+++ b/src/QtAVPlayer/qavdemuxer.cpp
@@ -6,6 +6,7 @@
  ***************************************************************/
 
 #include "qavdemuxer_p.h"
+#include "qavformatcontext_p.h"
 #include "qavvideocodec_p.h"
 #include "qavaudiocodec_p.h"
 #include "qavsubtitlecodec_p.h"
@@ -88,7 +89,7 @@ public:
     }
 
     QAVDemuxer *q_ptr = nullptr;
-    AVFormatContext *ctx = nullptr;
+    QSharedPointer<QAVFormatContext> ctx;
     AVBSFContext *bsf_ctx = nullptr;
 
     std::atomic_bool abortRequest = false;
@@ -362,16 +363,14 @@ int QAVDemuxer::load(const QString &url, QAVIODevice *dev)
 {
     Q_D(QAVDemuxer);
     QMutexLocker locker(&d->mutex);
-
-    if (!d->ctx)
-        d->ctx = avformat_alloc_context();
-
-    d->ctx->flags |= AVFMT_FLAG_GENPTS;
-    d->ctx->interrupt_callback.callback = decode_interrupt_cb;
-    d->ctx->interrupt_callback.opaque = d;
+    Q_ASSERT(!d->ctx);
+    d->ctx = QAVFormatContext::alloc();
+    d->ctx->ctx()->flags |= AVFMT_FLAG_GENPTS;
+    d->ctx->ctx()->interrupt_callback.callback = decode_interrupt_cb;
+    d->ctx->ctx()->interrupt_callback.opaque = d;
     if (dev) {
-        d->ctx->pb = dev->ctx();
-        d->ctx->flags |= AVFMT_FLAG_CUSTOM_IO;
+        d->ctx->ctx()->pb = dev->ctx();
+        d->ctx->ctx()->flags |= AVFMT_FLAG_CUSTOM_IO;
     }
 
 #if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(59, 0, 0)
@@ -391,18 +390,18 @@ int QAVDemuxer::load(const QString &url, QAVIODevice *dev)
     for (const auto & key: d->inputOptions.keys())
         av_dict_set(&opts.dict, key.toUtf8().constData(), d->inputOptions[key].toUtf8().constData(),
                     0);
-    int ret = avformat_open_input(&d->ctx, url.toUtf8().constData(), inputFormat, &opts.dict);
+    int ret = avformat_open_input(&d->ctx->ctx(), url.toUtf8().constData(), inputFormat, &opts.dict);
     if (ret < 0)
         return ret;
 
-    ret = avformat_find_stream_info(d->ctx, NULL);
+    ret = avformat_find_stream_info(d->ctx->ctx(), NULL);
     if (ret < 0)
         return ret;
 
 #if LIBAVUTIL_VERSION_INT < AV_VERSION_INT(59, 8, 0)
-    d->seekable = d->ctx->iformat->read_seek || d->ctx->iformat->read_seek2;
-    if (d->ctx->pb)
-        d->seekable |= bool(d->ctx->pb->seekable);
+    d->seekable = d->ctx->ctx()->iformat->read_seek || d->ctx->ctx()->iformat->read_seek2;
+    if (d->ctx->ctx()->pb)
+        d->seekable |= bool(d->ctx->ctx()->pb->seekable);
 #else
     // TODO: Search and implement replacement function for seek
     d->seekable = true;
@@ -413,7 +412,7 @@ int QAVDemuxer::load(const QString &url, QAVIODevice *dev)
         return ret;
 
     const int videoStreamIndex = av_find_best_stream(
-        d->ctx,
+        d->ctx->ctx(),
         AVMEDIA_TYPE_VIDEO,
         -1,
         -1,
@@ -423,7 +422,7 @@ int QAVDemuxer::load(const QString &url, QAVIODevice *dev)
         d->currentVideoStreams.push_back(d->availableStreams[videoStreamIndex]);
 
     const int audioStreamIndex = av_find_best_stream(
-        d->ctx,
+        d->ctx->ctx(),
         AVMEDIA_TYPE_AUDIO,
         -1,
         videoStreamIndex,
@@ -433,7 +432,7 @@ int QAVDemuxer::load(const QString &url, QAVIODevice *dev)
         d->currentAudioStreams.push_back(d->availableStreams[audioStreamIndex]);
 
     const int subtitleStreamIndex = av_find_best_stream(
-        d->ctx,
+        d->ctx->ctx(),
         AVMEDIA_TYPE_SUBTITLE,
         -1,
         audioStreamIndex >= 0 ? audioStreamIndex : videoStreamIndex,
@@ -446,7 +445,7 @@ int QAVDemuxer::load(const QString &url, QAVIODevice *dev)
         return ret;
 
     if (!d->bsfs.isEmpty())
-        return apply_bsf(d->bsfs, d->ctx, d->bsf_ctx);
+        return apply_bsf(d->bsfs, d->ctx->ctx(), d->bsf_ctx);
 
     return 0;
 }
@@ -455,13 +454,13 @@ int QAVDemuxer::resetCodecs()
 {
     Q_D(QAVDemuxer);
     int ret = 0;
-    for (std::size_t i = 0; i < d->ctx->nb_streams && ret >= 0; ++i) {
-        if (!d->ctx->streams[i]->codecpar) {
+    for (std::size_t i = 0; i < d->ctx->ctx()->nb_streams && ret >= 0; ++i) {
+        if (!d->ctx->ctx()->streams[i]->codecpar) {
             qWarning() << "Could not find codecpar";
             return AVERROR(EINVAL);
         }
 
-        const AVMediaType type = d->ctx->streams[i]->codecpar->codec_type;
+        const AVMediaType type = d->ctx->ctx()->streams[i]->codecpar->codec_type;
         switch (type) {
             case AVMEDIA_TYPE_VIDEO:
             {
@@ -475,12 +474,12 @@ int QAVDemuxer::resetCodecs()
             } break;
             case AVMEDIA_TYPE_AUDIO:
                 d->availableStreams.push_back({ int(i), d->ctx, QSharedPointer<QAVCodec>(new QAVAudioCodec) });
-                if (!d->availableStreams.last().codec()->open(d->ctx->streams[i]))
+                if (!d->availableStreams.last().codec()->open(d->ctx->ctx()->streams[i]))
                     qWarning() << "Could not open audio codec for stream:" << i;
                 break;
             case AVMEDIA_TYPE_SUBTITLE:
                 d->availableStreams.push_back({ int(i), d->ctx, QSharedPointer<QAVCodec>(new QAVSubtitleCodec) });
-                if (!d->availableStreams.last().codec()->open(d->ctx->streams[i]))
+                if (!d->availableStreams.last().codec()->open(d->ctx->ctx()->streams[i]))
                     qWarning() << "Could not open subtitle codec for stream:" << i;
                 break;
             default:
@@ -646,17 +645,13 @@ AVFormatContext *QAVDemuxer::avctx() const
 {
     Q_D(const QAVDemuxer);
     QMutexLocker locker(&d->mutex);
-    return d->ctx;
+    return d->ctx ? d->ctx->ctx() : nullptr;
 }
 
 void QAVDemuxer::unload()
 {
     Q_D(QAVDemuxer);
     QMutexLocker locker(&d->mutex);
-    if (d->ctx) {
-        avformat_close_input(&d->ctx);
-        avformat_free_context(d->ctx);
-    }
     d->ctx = nullptr;
     d->eof = false;
     d->abortRequest = 0;
@@ -686,7 +681,7 @@ int QAVDemuxer::read(QAVPacket &pkt)
             return 0;
         }
 
-        if (!d->ctx || d->eof) {
+        if (!d->ctx || !d->ctx->ctx() || d->eof) {
             pkt = QAVPacket();
             return AVERROR_EOF;
         }
@@ -694,9 +689,9 @@ int QAVDemuxer::read(QAVPacket &pkt)
 
     av_packet_unref(pkt.packet());
     bool eof = false;
-    int ret = av_read_frame(d->ctx, pkt.packet());
+    int ret = av_read_frame(d->ctx->ctx(), pkt.packet());
     if (ret < 0) {
-        if (ret == AVERROR_EOF || avio_feof(d->ctx->pb)) {
+        if (ret == AVERROR_EOF || avio_feof(d->ctx->ctx()->pb)) {
             eof = true;
         } else {
             qDebug() << "av_read_frame: unexpected result:" << ret;
@@ -799,7 +794,7 @@ int QAVDemuxer::seek(double sec)
 {
     Q_D(QAVDemuxer);
     QMutexLocker locker(&d->mutex);
-    if (!d->ctx || !d->seekable)
+    if (!d->ctx || !d->ctx->ctx() || !d->seekable)
         return AVERROR(EINVAL);
 
     d->eof = false;
@@ -809,16 +804,17 @@ int QAVDemuxer::seek(double sec)
     int64_t target = sec * AV_TIME_BASE;
     int64_t min = INT_MIN;
     int64_t max = target;
-    return avformat_seek_file(d->ctx, -1, min, target, max, flags);
+    return avformat_seek_file(d->ctx->ctx(), -1, min, target, max, flags);
 }
 
 double QAVDemuxer::duration() const
 {
     Q_D(const QAVDemuxer);
-    if (!d->ctx || d->ctx->duration == AV_NOPTS_VALUE)
+    QMutexLocker locker(&d->mutex);
+    if (!d->ctx || !d->ctx->ctx() || d->ctx->ctx()->duration == AV_NOPTS_VALUE)
         return 0.0;
 
-    return d->ctx->duration * av_q2d({1, AV_TIME_BASE});
+    return d->ctx->ctx()->duration * av_q2d({1, AV_TIME_BASE});
 }
 
 double QAVDemuxer::videoFrameRate() const
@@ -830,7 +826,7 @@ double QAVDemuxer::videoFrameRate() const
     // TODO:
     double ret = std::numeric_limits<double>::max();
     for (const auto &stream: d->currentVideoStreams) {
-        AVRational fr = av_guess_frame_rate(d->ctx, d->ctx->streams[stream.index()], NULL);
+        AVRational fr = av_guess_frame_rate(d->ctx->ctx(), d->ctx->ctx()->streams[stream.index()], NULL);
         double rate = fr.num && fr.den ? av_q2d({fr.den, fr.num}) : 0.0;
         if (rate < ret)
             ret = rate;
@@ -843,11 +839,11 @@ QMap<QString, QString> QAVDemuxer::metadata() const
 {
     Q_D(const QAVDemuxer);
     QMap<QString, QString> result;
-    if (d->ctx == nullptr)
+    if (!d->ctx || !d->ctx->ctx())
         return result;
 
     AVDictionaryEntry *tag = nullptr;
-    while ((tag = av_dict_get(d->ctx->metadata, "", tag, AV_DICT_IGNORE_SUFFIX)))
+    while ((tag = av_dict_get(d->ctx->ctx()->metadata, "", tag, AV_DICT_IGNORE_SUFFIX)))
         result[QString::fromUtf8(tag->key)] = QString::fromUtf8(tag->value);
 
     return result;
@@ -866,10 +862,10 @@ int QAVDemuxer::applyBitstreamFilter(const QString &bsfs)
     QMutexLocker locker(&d->mutex);
     d->bsfs = bsfs;
     int ret = 0;
-    if (d->ctx) {
+    if (d->ctx && d->ctx->ctx()) {
         av_bsf_free(&d->bsf_ctx);
         d->bsf_ctx = nullptr;
-        ret = apply_bsf(d->bsfs, d->ctx, d->bsf_ctx);
+        ret = apply_bsf(d->bsfs, d->ctx->ctx(), d->bsf_ctx);
     }
     return ret;
 }

--- a/src/QtAVPlayer/qavformatcontext.cpp
+++ b/src/QtAVPlayer/qavformatcontext.cpp
@@ -1,0 +1,45 @@
+/***************************************************************
+ * Copyright (C) 2020, 2026, Val Doroshchuk <valbok@gmail.com> *
+ *                                                             *
+ * This file is part of QtAVPlayer.                            *
+ * Free Qt Media Player based on FFmpeg.                       *
+ ***************************************************************/
+
+#include "qavformatcontext_p.h"
+#include <QDebug>
+
+extern "C" {
+#include <libavformat/avformat.h>
+}
+
+QT_BEGIN_NAMESPACE
+
+QAVFormatContext::~QAVFormatContext()
+{
+    if (m_ctx) {
+        avformat_close_input(&m_ctx);
+        avformat_free_context(m_ctx);
+    }
+}
+
+AVFormatContext *&QAVFormatContext::ctx()
+{
+    return m_ctx;
+}
+
+QSharedPointer<QAVFormatContext> QAVFormatContext::alloc(const QString &filename)
+{
+    QSharedPointer<QAVFormatContext> ret(new QAVFormatContext);
+    if (filename.isEmpty()) {
+        ret->m_ctx = avformat_alloc_context();
+    } else {
+        int err = avformat_alloc_output_context2(&ret->m_ctx, nullptr, nullptr, filename.toUtf8().constData());
+        if (err) {
+            qWarning() << filename << ": Could not create output context:" << err;
+            return {};
+        }
+    }
+    return ret;
+}
+
+QT_END_NAMESPACE

--- a/src/QtAVPlayer/qavformatcontext_p.h
+++ b/src/QtAVPlayer/qavformatcontext_p.h
@@ -1,0 +1,43 @@
+/***************************************************************
+ * Copyright (C) 2020, 2026, Val Doroshchuk <valbok@gmail.com> *
+ *                                                             *
+ * This file is part of QtAVPlayer.                            *
+ * Free Qt Media Player based on FFmpeg.                       *
+ ***************************************************************/
+
+#ifndef QAVFORMATCONTEXT_P_H
+#define QAVFORMATCONTEXT_P_H
+
+//
+//  W A R N I N G
+//  -------------
+//
+// This file is not part of the Qt API. It exists purely as an
+// implementation detail. This header file may change from version to
+// version without notice, or even be removed.
+//
+// We mean it.
+//
+
+#include <QtAVPlayer/qtavplayerglobal.h>
+#include <QSharedPointer>
+
+QT_BEGIN_NAMESPACE
+
+struct AVFormatContext;
+class Q_AVPLAYER_EXPORT QAVFormatContext
+{
+public:
+    ~QAVFormatContext();
+    AVFormatContext *&ctx();
+
+    static QSharedPointer<QAVFormatContext> alloc(const QString &filename = {});
+
+private:
+    QAVFormatContext() = default;
+    AVFormatContext *m_ctx = nullptr;
+};
+
+QT_END_NAMESPACE
+
+#endif

--- a/src/QtAVPlayer/qavmuxer.cpp
+++ b/src/QtAVPlayer/qavmuxer.cpp
@@ -10,6 +10,7 @@
 #include "qavaudiocodec_p.h"
 #include "qavsubtitlecodec_p.h"
 #include "qavvideoframe.h"
+#include "qavformatcontext_p.h"
 
 #include <QObject>
 #include <QThread>
@@ -48,7 +49,7 @@ public:
     // Allows to mux frames or packets from different sources.
     QMap<AVStream *, int> outputStreams;
     QString filename;
-    AVFormatContext *ctx = nullptr;
+    QSharedPointer<QAVFormatContext> ctx;
     bool loaded = false;
     mutable QMutex mutex;
 };
@@ -127,9 +128,8 @@ void QAVMuxer::reset(Locker &locker)
 {
     Q_D(QAVMuxer);
     close(locker);
-    if (d->ctx && !(d->ctx->oformat->flags & AVFMT_NOFILE))
-        avio_closep(&d->ctx->pb);
-    avformat_free_context(d->ctx);
+    if (d->ctx && d->ctx->ctx() && !(d->ctx->ctx()->oformat->flags & AVFMT_NOFILE))
+        avio_closep(&d->ctx->ctx()->pb);
     d->ctx = nullptr;
     d->inputStreams.clear();
     d->outputStreams.clear();
@@ -139,9 +139,9 @@ void QAVMuxer::reset(Locker &locker)
 void QAVMuxer::close(Locker &locker)
 {
     Q_D(QAVMuxer);
-    if (d->ctx && d->loaded) {
+    if (d->ctx && d->ctx->ctx() && d->loaded) {
         flushFrames(locker);
-        av_write_trailer(d->ctx);
+        av_write_trailer(d->ctx->ctx());
     }
     d->loaded = false;
 }
@@ -151,19 +151,17 @@ int QAVMuxer::load(const QList<QAVStream> &streams, const QString &filename)
     Q_D(QAVMuxer);
     QMutexLocker locker(&d->mutex);
     reset(locker);
-    int ret = avformat_alloc_output_context2(&d->ctx, nullptr, nullptr, filename.toUtf8().constData());
-    if (ret < 0) {
-        qWarning() << filename << ": Could not create output context:" << err2str(ret);
-        return ret;
-    }
+    d->ctx = QAVFormatContext::alloc(filename);
+    if (!d->ctx)
+        return AVERROR(EINVAL);
     d->inputStreams = streams;
     d->filename = filename;
-    ret = initMuxer(locker);
+    int ret = initMuxer(locker);
     if (ret < 0)
         return ret;
 
-    if (!(d->ctx->oformat->flags & AVFMT_NOFILE)) {
-        ret = avio_open(&d->ctx->pb, filename.toUtf8().constData(), AVIO_FLAG_WRITE);
+    if (!(d->ctx->ctx()->oformat->flags & AVFMT_NOFILE)) {
+        ret = avio_open(&d->ctx->ctx()->pb, filename.toUtf8().constData(), AVIO_FLAG_WRITE);
         if (ret < 0) {
             qWarning() << "Could not open output file:" << filename << ":"<< err2str(ret);
             return ret;
@@ -171,7 +169,7 @@ int QAVMuxer::load(const QList<QAVStream> &streams, const QString &filename)
     }
 
     // Init muxer, write output file header
-    ret = avformat_write_header(d->ctx, nullptr);
+    ret = avformat_write_header(d->ctx->ctx(), nullptr);
     if (ret < 0) {
         qWarning() << filename << ": Failed avformat_write_header:" << err2str(ret);
         return ret;
@@ -191,7 +189,7 @@ int QAVMuxer::initMuxer(Locker &locker)
         if (!stream.codec())
             return AVERROR(EINVAL);
         auto dec_ctx = codec->avctx();
-        auto out_stream = avformat_new_stream(d->ctx, NULL);
+        auto out_stream = avformat_new_stream(d->ctx->ctx(), NULL);
         if (!out_stream) {
             qWarning() << "Failed allocating output stream";
             return AVERROR_UNKNOWN;
@@ -203,12 +201,12 @@ int QAVMuxer::initMuxer(Locker &locker)
             stream.codec()->codec()->name << ", codec_id" << dec_ctx->codec_id <<
             ", pix_fmt:" << dec_ctx->pix_fmt << (pix_fmt_desc ? pix_fmt_desc->name : "");
 
-        ret = initMuxer(stream, i, d->ctx->streams[i], locker);
+        ret = initMuxer(stream, i, d->ctx->ctx()->streams[i], locker);
         if (ret < 0)
             return ret;
         d->outputStreams[stream.stream()] = i;
     }
-    av_dump_format(d->ctx, 0, d->filename.toUtf8().constData(), 1);
+    av_dump_format(d->ctx->ctx(), 0, d->filename.toUtf8().constData(), 1);
     return 0;
 }
 
@@ -252,14 +250,14 @@ int QAVMuxerPackets::write(QAVPacket packet, int streamIndex, Locker &)
     AVPacket *enc_pkt = nullptr;
     if (stream) {
         auto in_stream = stream.stream();
-        Q_ASSERT(streamIndex < static_cast<int>(d->ctx->nb_streams));
-        auto out_stream = d->ctx->streams[streamIndex];
+        Q_ASSERT(streamIndex < static_cast<int>(d->ctx->ctx()->nb_streams));
+        auto out_stream = d->ctx->ctx()->streams[streamIndex];
         enc_pkt = packet.packet();
         enc_pkt->stream_index = streamIndex;
         av_packet_rescale_ts(enc_pkt, in_stream->time_base, out_stream->time_base);
         enc_pkt->pos = -1;
     }
-    return av_interleaved_write_frame(d->ctx, enc_pkt);
+    return av_interleaved_write_frame(d->ctx->ctx(), enc_pkt);
 }
 
 int QAVMuxer::flush()
@@ -274,9 +272,9 @@ int QAVMuxer::flush()
 int QAVMuxerPackets::flushFrames(Locker &locker)
 {
     Q_D(QAVMuxer);
-    for (unsigned i = 0; i < d->ctx->nb_streams; ++i) {
+    for (unsigned i = 0; i < d->ctx->ctx()->nb_streams; ++i) {
         // no flushing for subtitles
-        bool isSub = d->ctx->streams[i]->codecpar->codec_type == AVMEDIA_TYPE_SUBTITLE;
+        bool isSub = d->ctx->ctx()->streams[i]->codecpar->codec_type == AVMEDIA_TYPE_SUBTITLE;
         if (isSub)
             continue;
         int ret = write(QAVPacket(), i, locker);
@@ -359,7 +357,7 @@ int QAVMuxerFrames::initMuxer(const QAVStream &stream, int index, AVStream *out_
             enc_ctx->sample_aspect_ratio = dec_ctx->sample_aspect_ratio;
             enc_ctx->pix_fmt = dec_ctx->pix_fmt;
             enc_ctx->time_base = in_stream->time_base;
-            if (d->ctx->oformat->flags & AVFMT_GLOBALHEADER)
+            if (d->ctx->ctx()->oformat->flags & AVFMT_GLOBALHEADER)
                 enc_ctx->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
             if (!codec->open(out_stream)) {
                 qWarning() << stream.index() << ": Cannot open encoder:" << encoder->name;
@@ -387,7 +385,7 @@ int QAVMuxerFrames::initMuxer(const QAVStream &stream, int index, AVStream *out_
 #endif
             enc_ctx->sample_fmt = dec_ctx->sample_fmt;
             enc_ctx->time_base = in_stream->time_base;
-            if (d->ctx->oformat->flags & AVFMT_GLOBALHEADER)
+            if (d->ctx->ctx()->oformat->flags & AVFMT_GLOBALHEADER)
                 enc_ctx->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
             if (!codec->open(out_stream)) {
                 qWarning() << stream.index() << ": Cannot open encoder:" << encoder->name;
@@ -501,7 +499,7 @@ int QAVMuxerFrames::write(QAVFrame frame, int streamIndex, Locker &)
 #if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(59, 0, 0)
             enc_pkt->time_base = stream->time_base;
 #endif
-            wrote = av_interleaved_write_frame(d->ctx, enc_pkt);
+            wrote = av_interleaved_write_frame(d->ctx->ctx(), enc_pkt);
         }
     } while (sent == AVERROR(EAGAIN));
     return 0;
@@ -531,7 +529,7 @@ int QAVMuxerFrames::write(QAVSubtitleFrame frame, int streamIndex, Locker &)
 #if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(59, 0, 0)
     enc_pkt->time_base = stream->time_base;
 #endif
-    int wrote = av_interleaved_write_frame(d->ctx, enc_pkt);
+    int wrote = av_interleaved_write_frame(d->ctx->ctx(), enc_pkt);
     return wrote;
 }
 
@@ -586,7 +584,7 @@ public:
 
     QAVMuxerSubtitleFrames *q_ptr = nullptr;
     QAVStream outputStream;
-    AVFormatContext *ctx = nullptr;
+    QSharedPointer<QAVFormatContext> ctx;
 };
 
 QAVMuxerSubtitleFrames::QAVMuxerSubtitleFrames()
@@ -608,10 +606,10 @@ int QAVMuxerSubtitleFrames::load(const QAVStream &stream)
         return AVERROR_INVALIDDATA;
     }
 
-    d_ptr->ctx = avformat_alloc_context();
+    d_ptr->ctx = QAVFormatContext::alloc();
     auto in_stream = stream.stream();
     auto dec_ctx = stream.codec()->avctx();
-    auto out_stream = avformat_new_stream(d->ctx, NULL);
+    auto out_stream = avformat_new_stream(d->ctx->ctx(), NULL);
 
     QSharedPointer<QAVCodec> codec(new QAVSubtitleCodec(encoder));
     auto enc_ctx = codec->avctx();
@@ -644,8 +642,6 @@ int QAVMuxerSubtitleFrames::load(const QAVStream &stream)
 void QAVMuxerSubtitleFrames::unload()
 {
     Q_D(QAVMuxerSubtitleFrames);
-    if (d->ctx)
-        avformat_free_context(d->ctx);
     d->ctx = nullptr;
     d->outputStream = {};
 }

--- a/src/QtAVPlayer/qavstream.cpp
+++ b/src/QtAVPlayer/qavstream.cpp
@@ -6,7 +6,7 @@
  ***************************************************************/
 
 #include "qavstream.h"
-#include "qavdemuxer_p.h"
+#include "qavformatcontext_p.h"
 #include "qavcodec_p.h"
 #include <QDebug>
 #include <cmath>
@@ -28,7 +28,7 @@ public:
 
     QAVStream *q_ptr = nullptr;
     int index = -1;
-    AVFormatContext *ctx = nullptr;
+    QSharedPointer<QAVFormatContext> ctx;
     QSharedPointer<QAVCodec> codec;
     QMap<QString, QString> metadata;
 };
@@ -38,7 +38,7 @@ QAVStream::QAVStream()
 {
 }
 
-QAVStream::QAVStream(int index, AVFormatContext *ctx, const QSharedPointer<QAVCodec> &codec)
+QAVStream::QAVStream(int index, const QSharedPointer<QAVFormatContext> &ctx, const QSharedPointer<QAVCodec> &codec)
     : QAVStream()
 {
     d_ptr->index = index;
@@ -67,13 +67,13 @@ QAVStream &QAVStream::operator=(const QAVStream &other)
 QAVStream::operator bool() const
 {
     Q_D(const QAVStream);
-    return d->ctx != nullptr && d->codec && d->index >= 0;
+    return d->ctx && d->ctx->ctx() && d->codec && d->index >= 0;
 }
 
 AVStream *QAVStream::stream() const
 {
     Q_D(const QAVStream);
-    return d->index >= 0 && d->index < static_cast<int>(d->ctx->nb_streams) ? d->ctx->streams[d->index] : nullptr;
+    return d->index >= 0 && d->index < static_cast<int>(d->ctx->ctx()->nb_streams) ? d->ctx->ctx()->streams[d->index] : nullptr;
 }
 
 int QAVStream::index() const
@@ -143,8 +143,8 @@ double QAVStream::duration() const
     double ret = 0.0;
     if (s->duration != AV_NOPTS_VALUE)
         ret = s->duration * av_q2d(s->time_base);
-    if (!ret && d->ctx->duration != AV_NOPTS_VALUE)
-        ret = d->ctx->duration / AV_TIME_BASE;
+    if (!ret && d->ctx->ctx()->duration != AV_NOPTS_VALUE)
+        ret = d->ctx->ctx()->duration / AV_TIME_BASE;
     return ret;
 }
 
@@ -179,7 +179,7 @@ double QAVStream::frameRate() const
     auto s = stream();
     if (s == nullptr)
         return 0.0;
-    AVRational fr = av_guess_frame_rate(d->ctx, s, nullptr);
+    AVRational fr = av_guess_frame_rate(d->ctx->ctx(), s, nullptr);
     return fr.num && fr.den ? av_q2d({fr.den, fr.num}) : 0.0;
 }
 

--- a/src/QtAVPlayer/qavstream.h
+++ b/src/QtAVPlayer/qavstream.h
@@ -18,12 +18,13 @@ QT_BEGIN_NAMESPACE
 struct AVStream;
 struct AVFormatContext;
 class QAVCodec;
+class QAVFormatContext;
 class QAVStreamPrivate;
 class Q_AVPLAYER_EXPORT QAVStream
 {
 public:
     QAVStream();
-    QAVStream(int index, AVFormatContext *ctx = nullptr, const QSharedPointer<QAVCodec> &codec = {});
+    QAVStream(int index, const QSharedPointer<QAVFormatContext> &ctx = {}, const QSharedPointer<QAVCodec> &codec = {});
     QAVStream(const QAVStream &other);
     ~QAVStream();
     QAVStream &operator=(const QAVStream &other);

--- a/tests/auto/integration/qavplayer/tst_qavplayer.cpp
+++ b/tests/auto/integration/qavplayer/tst_qavplayer.cpp
@@ -108,6 +108,7 @@ private slots:
     void outputFile();
     void muxerFilters();
     void muxerMultiSourceFrames();
+    void framesAfterPlayerDestroyed();
 };
 
 void tst_QAVPlayer::initTestCase()
@@ -3553,6 +3554,36 @@ void tst_QAVPlayer::muxerMultiSourceFrames()
     QTRY_VERIFY(p.mediaStatus() == QAVPlayer::LoadedMedia);
     QVERIFY(!p.availableStreams().isEmpty());
     QCOMPARE(p.availableStreams().size(), 4);
+}
+
+void tst_QAVPlayer::framesAfterPlayerDestroyed()
+{
+    QFileInfo file(testData("small.mp4"));
+    auto p = std::make_unique<QAVPlayer>();
+
+    QAVVideoFrame videoFrame;
+    QObject::connect(p.get(), &QAVPlayer::videoFrame, p.get(), [&](const QAVVideoFrame &f) { videoFrame = f; });
+
+    p->setSource(file.absoluteFilePath());
+    p->pause();
+    QCOMPARE(p->state(), QAVPlayer::PausedState);
+    QTRY_COMPARE(p->mediaStatus(), QAVPlayer::LoadedMedia);
+    QTRY_VERIFY(videoFrame);
+    QVERIFY(videoFrame.pts() >= 0);
+    p->setSource({});
+    QTRY_COMPARE(p->mediaStatus(), QAVPlayer::NoMedia);
+    QVERIFY(videoFrame.pts() >= 0);
+
+    p = nullptr;
+    QVERIFY(videoFrame.pts() >= 0);
+
+    p = std::make_unique<QAVPlayer>();
+    QObject::connect(p.get(), &QAVPlayer::videoFrame, p.get(), [&](const QAVVideoFrame &f) { videoFrame = f; });
+    p->setSource(file.absoluteFilePath());
+    p->play();
+    QTRY_COMPARE(p->mediaStatus(), QAVPlayer::LoadedMedia);
+    // Destroy the player but the frame could be still active
+    p = nullptr;
 }
 
 QTEST_MAIN(tst_QAVPlayer)


### PR DESCRIPTION
If new source is set to the player, or the player is destroyed but there could be still alive frames. F.e. waiting to render. This produces the crashes since AVFormatContext was already closed when the frame is handled.

To fix this introduced `QAVFormatContext` wrapper that must be alive until all frames are landed and nothing will use AVFrame or AVStream internal objects.

Each `QAVFrame` contains its `QAVStream` which contains `QAVCodec` and now `QAVFormatContext`. 