### PR TITLE
Introduce QAVASSRenderer with -DQT_AVPLAYER_LIBASS=ON

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -40,7 +40,8 @@ jobs:
                                   libswresample-dev \
                                   libswscale-dev \
                                   libva-x11-2 \
-                                  libva-drm2
+                                  libva-drm2 \
+                                  libass-dev
 
       - name: Install Qt
         uses: jurplel/install-qt-action@v3
@@ -65,9 +66,9 @@ jobs:
         run: |
           export QT_LOGGING_RULES="qt.QtAVPlayer.debug=true"
           cd tests/auto/integration/qavdemuxer
-          qmake
+          qmake DEFINES+="QT_AVPLAYER_LIBASS"
           make CC=$CC CXX=$CXX
-          ./tst_qavdemuxer
+          ./tst_qavdemuxer -platform offscreen
           cd ../qavplayer
           qmake
           make CC=$CC CXX=$CXX
@@ -101,7 +102,7 @@ jobs:
         if: ${{ matrix.qt_version == '6.8.2' }}
         run: |
           cd examples/qml_player
-          cmake . -DQT_AVPLAYER_MULTIMEDIA=ON
+          cmake . -DQT_AVPLAYER_MULTIMEDIA=ON -DQT_AVPLAYER_LIBASS=ON
           make CC=$CC CXX=$CXX CXXFLAGS='-std=c++17' VERBOSE=1
 
   macos:

--- a/src/QtAVPlayer/QtAVPlayer.cmake
+++ b/src/QtAVPlayer/QtAVPlayer.cmake
@@ -7,6 +7,7 @@ option(QT_AVPLAYER_VA_X11 "Enable libva-x11" OFF)
 option(QT_AVPLAYER_VA_DRM "Enable libva-drm" OFF)
 option(QT_AVPLAYER_VDPAU "Enable vdpau" OFF)
 option(QT_AVPLAYER_WIDGET_OPENGL "Enable widget opengl" OFF)
+option(QT_AVPLAYER_LIBASS "Enable libass" OFF)
 
 find_library(AVDEVICE_LIBRARY REQUIRED NAMES avdevice)
 find_library(AVCODEC_LIBRARY REQUIRED NAMES avcodec)
@@ -272,4 +273,14 @@ if(QT_AVPLAYER_WIDGET_OPENGL)
         ${QtAVPlayer_SOURCES}
         ${QT_AVPLAYER_DIR}/qavwidget_opengl.cpp
     )
+endif()
+
+if(QT_AVPLAYER_LIBASS)
+    message(STATUS "QT_AVPLAYER_LIBASS is defined")
+    find_library(LIBASS_LIBRARY REQUIRED NAMES ass)
+    set(QtAVPlayer_LIBS
+        ${QtAVPlayer_LIBS}
+        ${LIBASS_LIBRARY}
+    )
+    add_definitions(-DQT_AVPLAYER_LIBASS)
 endif()

--- a/src/QtAVPlayer/QtAVPlayer.pri
+++ b/src/QtAVPlayer/QtAVPlayer.pri
@@ -117,6 +117,10 @@ contains(DEFINES, QT_AVPLAYER_VDPAU) {
     SOURCES += $$PWD/qavhwdevice_vdpau.cpp
 }
 
+contains(DEFINES, QT_AVPLAYER_LIBASS) {
+    LIBS += -lass
+}
+
 macos|darwin {
     PRIVATE_HEADERS += $$PWD/qavhwdevice_videotoolbox_p.h
     SOURCES += $$PWD/qavhwdevice_videotoolbox.mm

--- a/src/QtAVPlayer/qavmuxer.cpp
+++ b/src/QtAVPlayer/qavmuxer.cpp
@@ -18,6 +18,9 @@
 #include <QDebug>
 
 extern "C" {
+#if defined(QT_AVPLAYER_LIBASS)
+    #include <ass/ass.h>
+#endif
 #include <libavformat/avformat.h>
 #include <libavcodec/avcodec.h>
 #include <libavutil/pixdesc.h>
@@ -664,5 +667,122 @@ int QAVMuxerSubtitleFrames::parseText(const QAVSubtitleFrame &f, QString &out)
     out = QString::fromUtf8(reinterpret_cast<const char*>(pkt.packet()->data));
     return 0;
 }
+
+#if defined(QT_AVPLAYER_LIBASS)
+class QAVASSRendererPrivate : public QObject
+{
+    Q_DECLARE_PUBLIC(QAVASSRenderer)
+public:
+    QAVASSRendererPrivate(QAVASSRenderer *q)
+        : q_ptr(q)
+    {
+    }
+
+    QAVASSRenderer *q_ptr = nullptr;
+    ASS_Library *library = nullptr;
+    ASS_Renderer *renderer = nullptr;
+    ASS_Track *track = nullptr;
+};
+
+QAVASSRenderer::QAVASSRenderer()
+    : d_ptr(new QAVASSRendererPrivate(this))
+{
+}
+
+QAVASSRenderer::~QAVASSRenderer()
+{
+    unload();
+}
+
+int QAVASSRenderer::load(const QAVStream &stream)
+{
+    Q_D(QAVASSRenderer);
+    d->library = ass_library_init();
+    if (!d->library) {
+        qWarning() << "Could not initialize libass";
+        return AVERROR(EINVAL);
+    }
+    d->renderer = ass_renderer_init(d->library);
+    if (!d->renderer) {
+        qWarning() << "Could not initialize libass renderer";
+        return AVERROR(EINVAL);
+    }
+
+    ass_set_fonts(d->renderer, NULL, NULL, 1, NULL, 1);
+    d->track = ass_new_track(d->library);
+    if (!d->track) {
+        qWarning() << "Could not create a libass track";
+        return AVERROR(EINVAL);
+    }
+    auto dec_ctx = stream.codec()->avctx();
+    if (dec_ctx->subtitle_header) {
+        ass_process_codec_private(d->track,
+                                  (char*)dec_ctx->subtitle_header,
+                                  dec_ctx->subtitle_header_size);
+    }
+    return 0;
+}
+
+void QAVASSRenderer::unload()
+{
+    Q_D(QAVASSRenderer);
+    if (d->track)
+        ass_free_track(d->track);
+    if (d->renderer)
+        ass_renderer_done(d->renderer);
+    if (d->library)
+        ass_library_done(d->library);
+    d->track = nullptr;
+    d->renderer = nullptr;
+    d->library = nullptr;
+}
+
+QImage QAVASSRenderer::toImage(const QAVSubtitleFrame &frame, int width, int height)
+{
+    Q_D(QAVASSRenderer);
+    auto sub = frame.subtitle();
+    const int64_t start_time = av_rescale_q(sub->pts, AV_TIME_BASE_Q, av_make_q(1, 1000));
+    const int64_t duration = sub->end_display_time;
+    ass_set_frame_size(d->renderer, width, height);
+    for (size_t i = 0; i < sub->num_rects; ++i) {
+        char *ass_line = sub->rects[i]->ass;
+        if (!ass_line)
+            break;
+        ass_process_chunk(d->track, ass_line, strlen(ass_line), start_time, duration);
+    }
+    int detect_change = 0;
+    ASS_Image *image = ass_render_frame(d->renderer, d->track,
+                                        start_time, &detect_change);
+    QImage ret(width, height, QImage::Format_RGBA8888_Premultiplied);
+    ret.fill(Qt::transparent);
+
+    for (ASS_Image *i = image; i; i = i->next) {
+        int r = (i->color >> 24) & 0xFF;
+        int g = (i->color >> 16) & 0xFF;
+        int b = (i->color >> 8) & 0xFF;
+        int a = 255 - (i->color & 0xFF); // libass uses inverted alpha
+
+        for (int y = 0; y < i->h; ++y) {
+            for (int x = 0; x < i->w; ++x) {
+                int src_alpha = i->bitmap[y * i->stride + x];
+                if (src_alpha == 0) continue;
+                int dst_x = i->dst_x + x;
+                int dst_y = i->dst_y + y;
+                if (dst_x < 0 || dst_y < 0 || dst_x >= width || dst_y >= height)
+                    continue;
+
+                QColor dst = ret.pixelColor(dst_x, dst_y);
+                float alpha = (src_alpha / 255.0f) * (a / 255.0f);
+                int out_r = r * alpha + dst.red() * (1 - alpha);
+                int out_g = g * alpha + dst.green() * (1 - alpha);
+                int out_b = b * alpha + dst.blue() * (1 - alpha);
+                ret.setPixelColor(dst_x, dst_y, QColor(out_r, out_g, out_b, 255));
+            }
+        }
+    }
+
+    return ret;
+}
+#endif  // #if defined(QT_AVPLAYER_LIBASS)
 
 QT_END_NAMESPACE

--- a/src/QtAVPlayer/qavmuxer.h
+++ b/src/QtAVPlayer/qavmuxer.h
@@ -13,6 +13,9 @@
 #include <QtAVPlayer/qavsubtitleframe.h>
 #include <QMutexLocker>
 #include <memory>
+#if defined(QT_AVPLAYER_LIBASS)
+#include <QImage>
+#endif
 
 QT_BEGIN_NAMESPACE
 
@@ -127,6 +130,26 @@ private:
     Q_DECLARE_PRIVATE(QAVMuxerSubtitleFrames)
     std::unique_ptr<QAVMuxerSubtitleFramesPrivate> d_ptr;
 };
+
+#if defined(QT_AVPLAYER_LIBASS)
+class QAVASSRendererPrivate;
+class QAVASSRenderer
+{
+public:
+    QAVASSRenderer();
+    ~QAVASSRenderer();
+
+    int load(const QAVStream &stream);
+    void unload();
+
+    QImage toImage(const QAVSubtitleFrame &frame, int width, int height);
+
+private:
+    Q_DISABLE_COPY(QAVASSRenderer)
+    Q_DECLARE_PRIVATE(QAVASSRenderer)
+    std::unique_ptr<QAVASSRendererPrivate> d_ptr;
+};
+#endif  // #if defined(QT_AVPLAYER_LIBASS)
 
 QT_END_NAMESPACE
 

--- a/tests/auto/integration/qavdemuxer/qavdemuxer.pro
+++ b/tests/auto/integration/qavdemuxer/qavdemuxer.pro
@@ -2,7 +2,6 @@ TARGET = tst_qavdemuxer
 INCLUDEPATH += ../../../../src/ ../../../../src/QtAVPlayer
 include(../../../../src/QtAVPlayer/QtAVPlayer.pri)
 
-QT -= gui
 QT += testlib
 CONFIG += c++17 testcase console
 RESOURCES += files.qrc

--- a/tests/auto/integration/qavdemuxer/tst_qavdemuxer.cpp
+++ b/tests/auto/integration/qavdemuxer/tst_qavdemuxer.cpp
@@ -45,6 +45,9 @@ private slots:
     void muxerWriteFrames();
     void muxerWriteSubtitles();
     void muxerWriteSubtitlesText();
+#if defined(QT_AVPLAYER_LIBASS)
+    void assRenderer();
+#endif
     void muxerEnqueue();
     void muxerEnqueueStreamIndex();
     void muxerEnqueueFramesFromMultiSources();
@@ -572,6 +575,44 @@ void tst_QAVDemuxer::muxerWriteSubtitlesText()
         m.unload();
     }
 }
+
+#if defined(QT_AVPLAYER_LIBASS)
+void tst_QAVDemuxer::assRenderer()
+{
+    QFileInfo file(testData("colors_subtitles.mkv"));
+    QAVDemuxer d;
+    QAVASSRenderer m;
+
+    QVERIFY(d.load(file.absoluteFilePath()) >= 0);
+    QVERIFY(!d.availableSubtitleStreams().isEmpty());
+    auto streams = d.currentVideoStreams();
+    QVERIFY(!streams.isEmpty());
+    auto avctx = streams[0].codec()->avctx();
+    QSize size(avctx->width, avctx->height);
+    for (auto &s: d.availableSubtitleStreams()) {
+        QVERIFY(m.load(s) >= 0);
+        QAVPacket p;
+        while (d.read(p) >= 0) {
+            switch (p.stream().codec()->avctx()->codec_type) {
+            case AVMEDIA_TYPE_SUBTITLE: {
+                QList<QAVSubtitleFrame> fs;
+                QAVDemuxer::decode(p, fs);
+                if (fs.size()) {
+                    QVERIFY(fs.size() == 1);
+                    auto &f = fs[0];
+                    auto img = m.toImage(f, size.width(), size.height());
+                    QVERIFY(!img.isNull());
+                }
+                break;
+            }
+            default:
+                break;
+            }
+        }
+        m.unload();
+    }
+}
+#endif  // #if defined(QT_AVPLAYER_LIBASS)
 
 void tst_QAVDemuxer::muxerEnqueue()
 {


### PR DESCRIPTION
QAVASSRenderer is supposed to convert QAVSubtitleFrame to QImage that could be blended to the video output. It uses libass to parse the subtitles.