### PR TITLE
Add ASS renderer to qml player example

### DIFF
--- a/examples/qml_player/main.cpp
+++ b/examples/qml_player/main.cpp
@@ -17,6 +17,11 @@ int main(int argc, char *argv[])
     app.setApplicationName("QtAVPlayer QML Demo");
     app.setApplicationVersion("1.0");
 
+    qmlRegisterType<SubtitleItem>(
+        "Subtitles",
+        1,
+        0,
+        "SubtitleItem");
     QQmlApplicationEngine engine;
 
     // Register PlayerController so QML can instantiate it or we expose it via context
@@ -34,5 +39,8 @@ int main(int argc, char *argv[])
     );
 
     engine.load(url);
+    auto rootObject = engine.rootObjects().first();
+    auto subtitleItem = rootObject->findChild<SubtitleItem *>(QString::fromLatin1("subtitleImage"));
+    controller.setSubtitleItem(subtitleItem);
     return app.exec();
 }

--- a/examples/qml_player/main.qml
+++ b/examples/qml_player/main.qml
@@ -3,6 +3,7 @@ import QtQuick.Controls
 import QtQuick.Layouts
 import QtQuick.Dialogs
 import QtMultimedia
+import Subtitles 1.0
 
 ApplicationWindow {
     id: root
@@ -26,6 +27,7 @@ ApplicationWindow {
     readonly property color textPrimary:  "#f0ede6"
     readonly property color textMuted:    "#666"
     readonly property int   radius:       6
+    property bool textedSubtitles:               false
     property string selectedSubtitleStreamIndex: "-1"
     property string selectedAudioStreamIndex:    "-1"
     property string selectedVideoStreamIndex:    "-1"
@@ -140,10 +142,23 @@ ApplicationWindow {
             selectedSubtitleStreamIndex = idx;
         }
         function onSubtitleTextChanged(text, ms) {
-            subtitle.text = text
-            subtitle.visible = true
-            subtitleTimer.interval = ms
-            subtitleTimer.restart()
+            if (!textedSubtitles) {
+                subtitle.visible = false;
+                return;
+            }
+            subtitle.text = text;
+            subtitle.visible = true;
+            subtitleTimer.interval = ms;
+            subtitleTimer.restart();
+        }
+        function onSubtitleImageChanged(img, ms) {
+            if (textedSubtitles) {
+                subtitleImage.visible = false;
+                return;
+            }
+            subtitleImage.visible = true;
+            subtitleImageTimer.interval = ms;
+            subtitleImageTimer.restart();
         }
         function onAudioTracksChanged() {
             audioMenuModel.clear()
@@ -167,6 +182,12 @@ ApplicationWindow {
             softwareVideoCodec = !hw;
             copyFreeMenu.enabled = !softwareVideoCodec;
             softwareVideoCodecMenu.enabled = hw
+        }
+        function onAssRendererChanged(enabled) {
+            if (!enabled) {
+                textedSubtitlesMenu.enabled = false;
+                textedSubtitles = true;
+            }
         }
     }
 
@@ -284,6 +305,37 @@ ApplicationWindow {
                             radius: root.radius
                             implicitWidth: 200
                         }
+
+                        MenuSeparator {
+                            contentItem: Rectangle {
+                                implicitHeight: 1
+                                color: "#333"
+                            }
+                        }
+
+                        MenuItem {
+                            id: textedSubtitlesMenu
+                            contentItem: Text {
+                                leftPadding: 12
+                                text: "Texted subtitles"
+                                color: parent.enabled
+                                        ? textedSubtitles
+                                            ? root.accentColor
+                                                : parent.highlighted
+                                                    ? root.textPrimary
+                                                    : root.textMuted
+                                            : root.textMuted
+                                font.pixelSize: 13
+                                verticalAlignment: Text.AlignVCenter
+                            }
+                            background: Rectangle {
+                                color: parent.highlighted ? Qt.rgba(1,1,1,0.06) : "transparent"
+                            }
+                            onTriggered: {
+                                textedSubtitles = !textedSubtitles;
+                            }
+                        }
+
 
                         Instantiator {
                             model: subtitleMenuModel
@@ -505,6 +557,18 @@ ApplicationWindow {
                 Component.onCompleted: {
                     playerController.setVideoSink(videoOutput.videoSink)
                 }
+
+                SubtitleItem {
+                    id: subtitleImage
+                    objectName: "subtitleImage"
+                    anchors.fill: parent
+                }
+                Timer {
+                    id: subtitleImageTimer
+                    interval: 4000
+                    onTriggered: subtitleImage.visible = false
+                }
+
             }
 
             // Double-click to toggle fullscreen

--- a/examples/qml_player/playercontroller.cpp
+++ b/examples/qml_player/playercontroller.cpp
@@ -13,6 +13,7 @@
 #include <QUrl>
 #include <QTimer>
 #include <QFileInfo>
+#include <QSGSimpleTextureNode>
 
 extern "C" {
 #include <libavcodec/avcodec.h>
@@ -25,6 +26,46 @@ static bool isStreamCurrent(int index, const QList<QAVStream> &streams)
             return true;
     }
     return false;
+}
+
+SubtitleItem::SubtitleItem(QQuickItem *parent)
+    : QQuickItem(parent)
+{
+    setFlag(ItemHasContents, true);
+    QImage ret(640, 480, QImage::Format_RGBA8888);
+    ret.fill(Qt::transparent);
+    m_image = ret;
+}
+
+void SubtitleItem::setImage(const QImage &img)
+{
+    QMutexLocker locker(&m_mutex);
+    m_image = img;
+    update();
+}
+
+QSGNode *SubtitleItem::updatePaintNode(QSGNode *oldNode, UpdatePaintNodeData *)
+{
+    auto *node =
+        static_cast<QSGSimpleTextureNode *>(oldNode);
+
+    if (!node)
+        node = new QSGSimpleTextureNode();
+
+    m_mutex.lock();
+    if (m_image.isNull()) {
+        m_mutex.unlock();
+        return node;
+    }
+
+    QSGTexture *texture =
+        window()->createTextureFromImage(m_image);
+
+    m_mutex.unlock();
+    node->setTexture(texture);
+    node->setRect(boundingRect());
+    node->setFiltering(QSGTexture::Linear);
+    return node;
 }
 
 PlayerController::PlayerController(QObject *parent)
@@ -59,6 +100,20 @@ void PlayerController::connectPlayerSignals()
         QString text;
         if (m_subtitleMuxer.parseText(frame, text) >= 0)
             emit subtitleTextChanged(text, frame.duration() * 1000);
+
+        auto size = m_videoSink->videoSize();
+        if (size.isEmpty()) {
+            auto streams = m_player.currentVideoStreams();
+            if (!streams.isEmpty()) {
+                auto avctx = streams[0].codec()->avctx();
+                size = {avctx->width, avctx->height};
+            }
+        }
+#if defined(QT_AVPLAYER_LIBASS)
+        auto img = m_subtitleRenderer.toImage(frame, size.width(), size.height());
+        if (!img.isNull())
+            emit subtitleImageChanged(img, frame.duration() * 1000);
+#endif
     }, Qt::DirectConnection);
 
     QObject::connect(&m_player, &QAVPlayer::played, this, [this](qint64 pos) {
@@ -136,6 +191,13 @@ void PlayerController::connectPlayerSignals()
     posTimer->start();
 }
 
+void PlayerController::setSubtitleItem(SubtitleItem *item)
+{
+    connect(this, &PlayerController::subtitleImageChanged, item, [item=item](const QImage &img) {
+        item->setImage(img);
+    });
+}
+
 void PlayerController::setVideoSink(QVideoSink *sink)
 {
     m_videoSink = sink;
@@ -192,6 +254,9 @@ void PlayerController::seek(qint64 ms)
 {
     m_audioOutput.setVolume(0);
     m_player.seek(ms);
+#if defined(QT_AVPLAYER_LIBASS)
+    m_subtitleRenderer.flush();
+#endif
 }
 
 void PlayerController::stepForward()
@@ -289,6 +354,13 @@ void PlayerController::notifyStreams()
         m_subtitleMuxer.unload();
         m_subtitleMuxer.load(i.second);
         emit subtitleTrackChanged(i.first);
+#if defined(QT_AVPLAYER_LIBASS)
+        m_subtitleRenderer.unload();
+        m_subtitleRenderer.load(i.second);
+        emit assRendererChanged(true);
+#else
+        emit assRendererChanged(false);
+#endif
     }
     emit audioTracksChanged();
     i = currentStream(m_player.availableAudioStreams(), m_player.currentAudioStreams());

--- a/examples/qml_player/playercontroller.h
+++ b/examples/qml_player/playercontroller.h
@@ -16,6 +16,24 @@
 #include <QString>
 #include <qqml.h>
 #include <QAtomicInt>
+#include <QQuickItem>
+
+class SubtitleItem : public QQuickItem
+{
+    Q_OBJECT
+public:
+    explicit SubtitleItem(QQuickItem *parent = nullptr);
+
+public slots:
+    void setImage(const QImage &img);
+
+protected:
+    QSGNode *updatePaintNode(QSGNode *oldNode, UpdatePaintNodeData *) override;
+
+private:
+    QImage m_image;
+    QMutex m_mutex;
+};
 
 /**
  * PlayerController
@@ -57,6 +75,7 @@ public:
     QStringList subtitleTracks() const;
     QStringList audioTracks() const;
     QStringList videoTracks() const;
+    void setSubtitleItem(SubtitleItem *item);
 
     void setVolume(qreal v);
 
@@ -87,11 +106,13 @@ signals:
     void subtitleTracksChanged();
     void subtitleTrackChanged(int index);
     void subtitleTextChanged(const QString &text, int duration);
+    void subtitleImageChanged(const QImage &img, int duration);
     void audioTracksChanged();
     void audioTrackChanged(int index);
     void videoTracksChanged();
     void videoTrackChanged(int index);
     void hwDeviceChanged(bool hw);
+    void assRendererChanged(bool enabled);
 
 private:
     void connectPlayerSignals();
@@ -103,7 +124,9 @@ private:
     QAVAudioOutput m_audioOutput;
     QVideoSink *m_videoSink = nullptr;
     QAVMuxerSubtitleFrames m_subtitleMuxer;
-
+#if defined(QT_AVPLAYER_LIBASS)
+    QAVASSRenderer m_subtitleRenderer;
+#endif
     bool m_playing = false;
     qint64 m_position = 0;
     qint64 m_duration = 0;

--- a/src/QtAVPlayer/qavmuxer.cpp
+++ b/src/QtAVPlayer/qavmuxer.cpp
@@ -741,6 +741,8 @@ void QAVASSRenderer::unload()
 QImage QAVASSRenderer::toImage(const QAVSubtitleFrame &frame, int width, int height)
 {
     Q_D(QAVASSRenderer);
+    if (!d->renderer)
+        return d->image;
     auto sub = frame.subtitle();
     const int64_t start_time = av_rescale_q(sub->pts, AV_TIME_BASE_Q, av_make_q(1, 1000));
     const int64_t duration = sub->end_display_time;


### PR DESCRIPTION
There are now two options how to render subtitles, by texts or like an image.