### PR TITLE
Add QAVCodec::size()

### DIFF
--- a/examples/qml_player/playercontroller.cpp
+++ b/examples/qml_player/playercontroller.cpp
@@ -104,10 +104,8 @@ void PlayerController::connectPlayerSignals()
         auto size = m_videoSink->videoSize();
         if (size.isEmpty()) {
             auto streams = m_player.currentVideoStreams();
-            if (!streams.isEmpty()) {
-                auto avctx = streams[0].codec()->avctx();
-                size = {avctx->width, avctx->height};
-            }
+            if (!streams.isEmpty())
+                size = streams[0].codec()->size();
         }
 #if defined(QT_AVPLAYER_LIBASS)
         auto img = m_subtitleRenderer.toImage(frame, size.width(), size.height());

--- a/src/QtAVPlayer/qavcodec.cpp
+++ b/src/QtAVPlayer/qavcodec.cpp
@@ -87,6 +87,14 @@ const AVCodec *QAVCodec::codec() const
     return d_func()->codec;
 }
 
+QSize QAVCodec::size() const
+{
+    Q_D(const QAVCodec);
+    if (!d->avctx)
+        return {};
+    return {d->avctx->width, d->avctx->height};
+}
+
 void QAVCodec::flushBuffers()
 {
      Q_D(QAVCodec);

--- a/src/QtAVPlayer/qavcodec_p.h
+++ b/src/QtAVPlayer/qavcodec_p.h
@@ -22,6 +22,7 @@
 #include "qavpacket.h"
 #include "qavframe.h"
 #include <QtAVPlayer/qtavplayerglobal.h>
+#include <QSize>
 #include <memory>
 
 extern "C" {
@@ -43,6 +44,7 @@ public:
     AVCodecContext *avctx() const;
     void setCodec(const AVCodec *c);
     const AVCodec *codec() const;
+    QSize size() const;
 
     void flushBuffers();
 

--- a/tests/auto/integration/qavdemuxer/tst_qavdemuxer.cpp
+++ b/tests/auto/integration/qavdemuxer/tst_qavdemuxer.cpp
@@ -1,5 +1,5 @@
 /***************************************************************
- * Copyright (C) 2020, 2025, Val Doroshchuk <valbok@gmail.com> *
+ * Copyright (C) 2020, 2026, Val Doroshchuk <valbok@gmail.com> *
  *                                                             *
  * This file is part of QtAVPlayer.                            *
  * Free Qt Media Player based on FFmpeg.                       *
@@ -587,8 +587,8 @@ void tst_QAVDemuxer::assRenderer()
     QVERIFY(!d.availableSubtitleStreams().isEmpty());
     auto streams = d.currentVideoStreams();
     QVERIFY(!streams.isEmpty());
-    auto avctx = streams[0].codec()->avctx();
-    QSize size(avctx->width, avctx->height);
+    QSize size = streams[0].codec()->size();
+    QVERIFY(!size.isNull());
     for (auto &s: d.availableSubtitleStreams()) {
         QVERIFY(m.load(s) >= 0);
         QAVPacket p;


### PR DESCRIPTION
Video-only: Those fields may not match the values of the last.
Useful to get the size before the decoding is started.