### PR TITLE
Use preferred audio output format if frame's format is not supported

### DIFF
--- a/src/QtAVPlayer/qavaudioconverter.cpp
+++ b/src/QtAVPlayer/qavaudioconverter.cpp
@@ -43,25 +43,24 @@ QAVAudioConverter::~QAVAudioConverter()
     av_freep(&d->audioBuf);
 }
 
-QByteArray QAVAudioConverter::data(const QAVAudioFrame &audioFrame)
+QByteArray QAVAudioConverter::data(const QAVAudioFrame &audioFrame, const QAVAudioFormat &outputFormat)
 {
     Q_D(QAVAudioConverter);
     const auto frame = audioFrame.frame();
-    if (!frame)
+    if (!frame || !outputFormat)
         return {};
 
     QByteArray audioData;
-    const auto fmt = audioFrame.format();
     AVSampleFormat outFormat = AV_SAMPLE_FMT_NONE;
 #if LIBAVUTIL_VERSION_INT <= AV_VERSION_INT(57, 23, 0)
-    int64_t outChannelLayout = av_get_default_channel_layout(fmt.channelCount());
+    int64_t outChannelLayout = av_get_default_channel_layout(outputFormat.channelCount());
 #else
     AVChannelLayout outChannelLayout;
-    av_channel_layout_default(&outChannelLayout, fmt.channelCount());
+    av_channel_layout_default(&outChannelLayout, outputFormat.channelCount());
 #endif
-    int outSampleRate = fmt.sampleRate();
+    int outSampleRate = outputFormat.sampleRate();
 
-    switch (fmt.sampleFormat()) {
+    switch (outputFormat.sampleFormat()) {
     case QAVAudioFormat::UInt8:
         outFormat = AV_SAMPLE_FMT_U8;
         break;
@@ -75,7 +74,7 @@ QByteArray QAVAudioConverter::data(const QAVAudioFrame &audioFrame)
         outFormat = AV_SAMPLE_FMT_FLT;
         break;
     default:
-        qWarning() << "Could not negotiate output format:" << fmt.sampleFormat();
+        qWarning() << "Could not negotiate output format:" << outputFormat.sampleFormat();
         return {};
     }
 
@@ -129,7 +128,7 @@ QByteArray QAVAudioConverter::data(const QAVAudioFrame &audioFrame)
     if (d->swr_ctx) {
         const uint8_t **in = (const uint8_t **)frame->extended_data;
         int outCount = (int64_t)frame->nb_samples * outSampleRate / frame->sample_rate + 256;
-        int outSize = av_samples_get_buffer_size(nullptr, fmt.channelCount(), outCount, outFormat, 0);
+        int outSize = av_samples_get_buffer_size(nullptr, outputFormat.channelCount(), outCount, outFormat, 0);
 
         av_freep(&d->audioBuf);
         uint8_t **out = &d->audioBuf;
@@ -142,7 +141,7 @@ QByteArray QAVAudioConverter::data(const QAVAudioFrame &audioFrame)
             return {};
         }
 
-        int size = samples * fmt.channelCount() * av_get_bytes_per_sample(outFormat);
+        int size = samples * outputFormat.channelCount() * av_get_bytes_per_sample(outFormat);
         // Make deep copy
         audioData = QByteArray((const char *)d->audioBuf, size);
     } else {

--- a/src/QtAVPlayer/qavaudioconverter_p.h
+++ b/src/QtAVPlayer/qavaudioconverter_p.h
@@ -1,9 +1,9 @@
-/*********************************************************
- * Copyright (C) 2024, Val Doroshchuk <valbok@gmail.com> *
- *                                                       *
- * This file is part of QtAVPlayer.                      *
- * Free Qt Media Player based on FFmpeg.                 *
- *********************************************************/
+/***************************************************************
+ * Copyright (C) 2020, 2026, Val Doroshchuk <valbok@gmail.com> *
+ *                                                             *
+ * This file is part of QtAVPlayer.                            *
+ * Free Qt Media Player based on FFmpeg.                       *
+ ***************************************************************/
 
 #ifndef QAVFAUDIOCONVERTER_H
 #define QAVFAUDIOCONVERTER_H
@@ -30,7 +30,8 @@ public:
     QAVAudioConverter();
     ~QAVAudioConverter();
 
-    QByteArray data(const QAVAudioFrame &frame);
+    // Converts audio data to outputFormat if the frame is in different format
+    QByteArray data(const QAVAudioFrame &frame, const QAVAudioFormat &outputFormat);
 
 private:
     Q_DISABLE_COPY(QAVAudioConverter)

--- a/src/QtAVPlayer/qavaudioframe.cpp
+++ b/src/QtAVPlayer/qavaudioframe.cpp
@@ -97,7 +97,7 @@ QByteArray QAVAudioFrame::data() const
     auto d = const_cast<QAVAudioFramePrivate *>(reinterpret_cast<QAVAudioFramePrivate *>(d_ptr.get()));
     if (d->data.isEmpty()) {
         d->outAudioFormat = format();
-        d->data = QAVAudioConverter().data(*this);
+        d->data = QAVAudioConverter().data(*this, format());
     }
     return d->data;
 }

--- a/src/QtAVPlayer/qavaudiooutput.cpp
+++ b/src/QtAVPlayer/qavaudiooutput.cpp
@@ -1,9 +1,9 @@
-/*********************************************************
- * Copyright (C) 2021, Val Doroshchuk <valbok@gmail.com> *
- *                                                       *
- * This file is part of QtAVPlayer.                      *
- * Free Qt Media Player based on FFmpeg.                 *
- *********************************************************/
+/***************************************************************
+ * Copyright (C) 2020, 2026, Val Doroshchuk <valbok@gmail.com> *
+ *                                                             *
+ * This file is part of QtAVPlayer.                            *
+ * Free Qt Media Player based on FFmpeg.                       *
+ ***************************************************************/
 
 #include "qavaudiooutput.h"
 #include "qavaudiooutputdevice_p.h"
@@ -77,6 +77,45 @@ static QAudioFormat format(const QAVAudioFormat &from)
     return out;
 }
 
+static QAVAudioFormat format(const QAudioFormat &from)
+{
+    QAVAudioFormat out;
+    out.setSampleRate(from.sampleRate());
+    out.setChannelCount(from.channelCount());
+
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    switch (from.sampleType()) {
+    case QAudioFormat::UnSignedInt:
+        out.setSampleFormat(QAVAudioFormat::UInt8);
+        break;
+    case QAudioFormat::SignedInt:
+        out.setSampleFormat(from.sampleSize() == 16 ? QAVAudioFormat::Int16 : QAVAudioFormat::Int32);
+        break;
+    case QAudioFormat::Float:
+        out.setSampleFormat(QAVAudioFormat::Float);
+        break;
+#else
+    switch (from.sampleFormat()) {
+    case QAudioFormat::UInt8:
+        out.setSampleFormat(QAVAudioFormat::UInt8);
+        break;
+    case QAudioFormat::Int16:
+        out.setSampleFormat(QAVAudioFormat::Int16);
+        break;
+    case QAudioFormat::Int32:
+        out.setSampleFormat(QAVAudioFormat::Int32);
+        break;
+    case QAudioFormat::Float:
+        out.setSampleFormat(QAVAudioFormat::Float);
+        break;
+#endif  // #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    default:
+        qWarning() << "Could not negotiate output format:" << from;
+        return {};
+    }
+    return out;
+}
+
 class QAVAudioOutputPrivate : public QObject
 {
 public:
@@ -101,10 +140,17 @@ public:
     std::unique_ptr<QAVAudioOutputDevice> device;
     std::unique_ptr<QThread> audioThread;
     AudioDevice defaultAudioDevice;
+    // Format of AudioOutputDevice
     QAudioFormat audioOutputFormat;
+    // Format of input frames
+    QAVAudioFormat frameInputFormat;
+    // Format of data to convert to feed AudioDevice
+    QAVAudioFormat frameOutputFormat;
+    // Indicates the reset is scheduled
+    bool resetPending = false;
     mutable QMutex mutex;
 
-    void resetIfNeeded(const QAudioFormat &fmt, int bsize, qreal v)
+    void resetIfNeeded(const QAVAudioFormat &frameFormat, int bsize, qreal v)
     {
         QMutexLocker locker(&mutex);
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
@@ -114,8 +160,13 @@ public:
         auto audioDevice = QMediaDevices::defaultAudioOutput();
         auto deviceName = audioDevice.description();
 #endif
+        auto fmt = format(frameFormat);
+#if QT_VERSION >= QT_VERSION_CHECK(6, 4, 0)
+        fmt.setChannelConfig(channelConfig);
+#endif
         if (!audioOutput
             || audioOutput->format() != fmt
+            || frameInputFormat != frameFormat
             || audioOutput->state() == QAudio::StoppedState
             || defaultAudioDevice != audioDevice)
         {
@@ -123,7 +174,6 @@ public:
                 qWarning() << "QAVAudioOutput initialization must be on the audio thread";
                 return;
             }
-
             if (audioOutput) {
                 audioOutput->stop();
                 audioOutput->deleteLater();
@@ -132,6 +182,12 @@ public:
             if (audioDevice.isNull() || deviceName.toLower() == QLatin1String("null audio device")) {
                 qDebug() << "Audio device is not supported:" << deviceName;
                 return;
+            }
+
+            if (!audioDevice.isFormatSupported(fmt)) {
+                auto preferred = audioDevice.preferredFormat();
+                qDebug() << "QAVAudioOutput:" << fmt << "is not supported, falling back to preferred:" << preferred;
+                fmt = preferred;
             }
 
             audioOutput = new AudioOutput(audioDevice, fmt);
@@ -146,6 +202,9 @@ public:
             // Start sending the audio frames from the queue to render
             device->start();
             audioOutputFormat = fmt;
+            frameInputFormat = frameFormat;
+            frameOutputFormat = format(fmt);
+            resetPending = false;
             locker.unlock();
             // Start the output without the lock to allow to add frames to the device.
             // This could wait for frames available.
@@ -232,32 +291,39 @@ bool QAVAudioOutput::play(const QAVAudioFrame &frame)
         d->device->flush();
         return false;
     }
-    auto fmt = format(frame.format());
-    if (!fmt.isValid())
-        return false;
-#if QT_VERSION >= QT_VERSION_CHECK(6, 4, 0)
-    fmt.setChannelConfig(d->channelConfig);
-#endif
     if (QThread::currentThread() == d->audioThread.get()) {
         qCritical() << "QAVAudioOutput::play() must not be called on the audio thread";
         return false;
     }
+    QAVAudioFormat frameFormat = frame.format();
+    if (!frameFormat)
+        return false;
     bool reset = false;
     {
         QMutexLocker locker(&d->mutex);
         // Check if the format has been changed or not yet initialized
-        reset = d->audioOutputFormat != fmt;
+        if (d->frameInputFormat != frameFormat) {
+            if (d->resetPending) {
+                d->device->clear();
+                return false;
+            }
+            d->frameInputFormat = {};
+            d->resetPending = true;
+            reset = true;
+        } else {
+            frameFormat = d->frameOutputFormat;
+        }
     }
     if (reset) {
         d->device->clear();
         // Reset the output on QAVAudioOutput's thread
-        QMetaObject::invokeMethod(d, [fmt, d] {
-            d->resetIfNeeded(fmt, d->bufferSize, d->volume);
+        QMetaObject::invokeMethod(d, [frameFormat, d] {
+            d->resetIfNeeded(frameFormat, d->bufferSize, d->volume);
         });
         return false;
     }
     // Add frames on current thread
-    d->device->play(frame);
+    d->device->play(frame, frameFormat);
     return true;
 }
 

--- a/src/QtAVPlayer/qavaudiooutputdevice.cpp
+++ b/src/QtAVPlayer/qavaudiooutputdevice.cpp
@@ -74,14 +74,14 @@ qint64 QAVAudioOutputDevice::readData(char *data, qint64 len)
     return bytesWritten;
 }
 
-void QAVAudioOutputDevice::play(const QAVAudioFrame &frame)
+void QAVAudioOutputDevice::play(const QAVAudioFrame &frame, const QAVAudioFormat &outputFormat)
 {
     Q_D(QAVAudioOutputDevice);
     {
         QMutexLocker locker(&d->mutex);
         if (!d->conv)
             return;
-        auto data = d->conv->data(frame);
+        auto data = d->conv->data(frame, outputFormat);
         d->bytes += data.size();
         d->frames.push_back(std::move(data));
     }

--- a/src/QtAVPlayer/qavaudiooutputdevice_p.h
+++ b/src/QtAVPlayer/qavaudiooutputdevice_p.h
@@ -42,7 +42,7 @@ public:
     bool atEnd() const override { return false; }
 
     // Enqueues the audio frame to be sent from readData()
-    void play(const QAVAudioFrame &frame);
+    void play(const QAVAudioFrame &frame, const QAVAudioFormat &outputFormat);
     // Start sending the audio data from readData()
     void start();
     // Don't send the audio data from readData()


### PR DESCRIPTION
When the audio device does not support the audio frame's format, it should use preferred one instead of silence.
But when the frame's format has been changed it needs to try new format again instead of preferred.