### PR TITLE
Resume QAudioSink before stopping

### DIFF
--- a/examples/qml_player/playercontroller.cpp
+++ b/examples/qml_player/playercontroller.cpp
@@ -122,7 +122,6 @@ void PlayerController::connectPlayerSignals()
         m_playing = true;
         emit playingChanged();
         m_audioOutput.setVolume(m_volume);
-        m_audioOutput.resume();
     });
 
     QObject::connect(&m_player, &QAVPlayer::paused, this, [this](qint64 pos) {
@@ -147,15 +146,12 @@ void PlayerController::connectPlayerSignals()
             emit positionChanged();
         }
         m_audioOutput.setVolume(m_volume);
-        m_audioOutput.resume();
     });
 
     QObject::connect(&m_player, &QAVPlayer::seeked, this, [this](qint64 pos) {
         m_position = pos;
         emit positionChanged();
         m_audioOutput.setVolume(m_volume);
-        if (m_playing)
-            m_audioOutput.resume();
     });
 
     QObject::connect(&m_player, &QAVPlayer::errorOccurred, this, [this](QAVPlayer::Error, const QString &str) {
@@ -240,6 +236,8 @@ void PlayerController::openUrl(const QString &url)
 
 void PlayerController::play()
 {
+    if (!m_playing)
+        m_audioOutput.resume();
     m_player.play();
 }
 
@@ -402,6 +400,8 @@ void PlayerController::reset()
     emit subtitleTrackChanged(-1);
     emit audioTracksChanged();
     emit videoTracksChanged();
+    m_audioOutput.clearQueue();
+    m_audioOutput.play({});
 }
 
 void PlayerController::setVideoCodec(const QString &codec)

--- a/src/QtAVPlayer/qavaudiooutput.cpp
+++ b/src/QtAVPlayer/qavaudiooutput.cpp
@@ -333,6 +333,12 @@ void QAVAudioOutput::stop()
 {
     Q_D(QAVAudioOutput);
     d->device->stop();
+    QMutexLocker locker(&d->mutex);
+    if (d->audioOutput) {
+        QMetaObject::invokeMethod(d, [audioOutput=d->audioOutput] {
+            audioOutput->reset();
+        });
+    }
 }
 
 void QAVAudioOutput::clearQueue()
@@ -346,11 +352,13 @@ void QAVAudioOutput::suspend()
     Q_D(QAVAudioOutput);
     QMutexLocker locker(&d->mutex);
     // Invoke on audio thread
-    QMetaObject::invokeMethod(d, [audioOutput=d->audioOutput] {
-        if (audioOutput && audioOutput->state() != QAudio::SuspendedState) {
-            audioOutput->suspend();
-        }
-    });
+    if (d->audioOutput) {
+        QMetaObject::invokeMethod(d, [audioOutput=d->audioOutput] {
+            if (audioOutput->state() != QAudio::SuspendedState) {
+                audioOutput->suspend();
+            }
+        });
+    }
 }
 
 void QAVAudioOutput::resume()
@@ -358,11 +366,13 @@ void QAVAudioOutput::resume()
     Q_D(QAVAudioOutput);
     QMutexLocker locker(&d->mutex);
     // Invoke on audio thread
-    QMetaObject::invokeMethod(d, [audioOutput=d->audioOutput] {
-        if (audioOutput && audioOutput->state() == QAudio::SuspendedState) {
-            audioOutput->resume();
-        }
-    });
+    if (d->audioOutput) {
+        QMetaObject::invokeMethod(d, [audioOutput=d->audioOutput] {
+            if (audioOutput->state() == QAudio::SuspendedState) {
+                audioOutput->resume();
+            }
+        });
+    }
 }
 
 QT_END_NAMESPACE

--- a/src/QtAVPlayer/qavaudiooutput.cpp
+++ b/src/QtAVPlayer/qavaudiooutput.cpp
@@ -176,6 +176,8 @@ public:
                 return;
             }
             if (audioOutput) {
+                if (audioOutput->state() == QAudio::SuspendedState)
+                    audioOutput->resume();
                 audioOutput->stop();
                 audioOutput->deleteLater();
                 audioOutput = nullptr;

--- a/src/QtAVPlayer/qavaudiooutput.cpp
+++ b/src/QtAVPlayer/qavaudiooutput.cpp
@@ -176,6 +176,7 @@ public:
                 return;
             }
             if (audioOutput) {
+                audioOutput->reset();
                 if (audioOutput->state() == QAudio::SuspendedState)
                     audioOutput->resume();
                 audioOutput->stop();


### PR DESCRIPTION
After suspend/resume added, QAudioSink requires to be reset before stopping, otherwise it will hang