### PR TITLE
Introduce cuda support

### DIFF
--- a/src/QtAVPlayer/QtAVPlayer.cmake
+++ b/src/QtAVPlayer/QtAVPlayer.cmake
@@ -59,6 +59,7 @@ set(QtAVPlayer_PRIVATE_HEADERS
     ${QT_AVPLAYER_DIR}/qavfilters_p.h
     ${QT_AVPLAYER_DIR}/qavaudioconverter_p.h
     ${QT_AVPLAYER_DIR}/qavformatcontext_p.h
+    ${QT_AVPLAYER_DIR}/qavhwdevice_cuda_p.h.h
 )
 
 set(QtAVPlayer_PUBLIC_HEADERS
@@ -113,6 +114,7 @@ set(QtAVPlayer_SOURCES
     ${QT_AVPLAYER_DIR}/qavfilters.cpp
     ${QT_AVPLAYER_DIR}/qavaudioconverter.cpp
     ${QT_AVPLAYER_DIR}/qavformatcontext.cpp
+    ${QT_AVPLAYER_DIR}/qavhwdevice_cuda.cpp
 )
 
 if(WIN32)

--- a/src/QtAVPlayer/QtAVPlayer.pri
+++ b/src/QtAVPlayer/QtAVPlayer.pri
@@ -33,6 +33,7 @@ PRIVATE_HEADERS += \
     $$PWD/qavfilters_p.h \
     $$PWD/qavaudioconverter_p.h \
     $$PWD/qavformatcontext_p.h \
+    $$PWD/qavhwdevice_cuda_p.h \
 
 PUBLIC_HEADERS += \
     $$PWD/qaviodevice.h \
@@ -85,6 +86,7 @@ SOURCES += \
     $$PWD/qavfilters.cpp \
     $$PWD/qavaudioconverter.cpp \
     $$PWD/qavformatcontext.cpp \
+    $$PWD/qavhwdevice_cuda.cpp \
 
 contains(DEFINES, QT_AVPLAYER_MULTIMEDIA) {
     QT += multimedia

--- a/src/QtAVPlayer/qavdemuxer.cpp
+++ b/src/QtAVPlayer/qavdemuxer.cpp
@@ -42,6 +42,8 @@ extern "C" {
 }
 #endif
 
+#include "qavhwdevice_cuda_p.h"
+
 #include <QDir>
 #include <QSharedPointer>
 #include <QMutexLocker>
@@ -240,6 +242,7 @@ static int setup_video_codec(const QString &inputVideoCodec, const QAVStream &st
     auto vm = QtAndroidPrivate::javaVM();
     av_jni_set_java_vm(vm, NULL);
 #endif
+    devices.append(QSharedPointer<QAVHWDevice>(new QAVHWDevice_CUDA));
 
     if (!ignoreHW) {
         AVBufferRef *hw_device_ctx = nullptr;

--- a/src/QtAVPlayer/qavhwdevice_cuda.cpp
+++ b/src/QtAVPlayer/qavhwdevice_cuda.cpp
@@ -1,0 +1,32 @@
+/***************************************************************
+ * Copyright (C) 2020, 2026, Val Doroshchuk <valbok@gmail.com> *
+ *                                                             *
+ * This file is part of QtAVPlayer.                            *
+ * Free Qt Media Player based on FFmpeg.                       *
+ ***************************************************************/
+
+#include "qavhwdevice_cuda_p.h"
+#include "qavvideobuffer_gpu_p.h"
+
+extern "C" {
+#include <libavutil/pixdesc.h>
+}
+
+QT_BEGIN_NAMESPACE
+
+AVPixelFormat QAVHWDevice_CUDA::format() const
+{
+    return AV_PIX_FMT_CUDA;
+}
+
+AVHWDeviceType QAVHWDevice_CUDA::type() const
+{
+    return AV_HWDEVICE_TYPE_CUDA;
+}
+
+QAVVideoBuffer *QAVHWDevice_CUDA::videoBuffer(const QAVVideoFrame &frame) const
+{
+    return new QAVVideoBuffer_GPU(frame);
+}
+
+QT_END_NAMESPACE

--- a/src/QtAVPlayer/qavhwdevice_cuda_p.h
+++ b/src/QtAVPlayer/qavhwdevice_cuda_p.h
@@ -1,0 +1,43 @@
+/***************************************************************
+ * Copyright (C) 2020, 2026, Val Doroshchuk <valbok@gmail.com> *
+ *                                                             *
+ * This file is part of QtAVPlayer.                            *
+ * Free Qt Media Player based on FFmpeg.                       *
+ ***************************************************************/
+
+#ifndef QAVHWDEVICE_CUDA_P_H
+#define QAVHWDEVICE_CUDA_P_H
+
+//
+//  W A R N I N G
+//  -------------
+//
+// This file is not part of the Qt API. It exists purely as an
+// implementation detail. This header file may change from version to
+// version without notice, or even be removed.
+//
+// We mean it.
+//
+
+#include "qavhwdevice_p.h"
+#include <memory>
+
+QT_BEGIN_NAMESPACE
+
+class Q_AVPLAYER_EXPORT QAVHWDevice_CUDA : public QAVHWDevice
+{
+public:
+    QAVHWDevice_CUDA() = default;
+    ~QAVHWDevice_CUDA() = default;
+
+    AVPixelFormat format() const override;
+    AVHWDeviceType type() const override;
+    QAVVideoBuffer *videoBuffer(const QAVVideoFrame &frame) const override;
+
+private:
+    Q_DISABLE_COPY(QAVHWDevice_CUDA)
+};
+
+QT_END_NAMESPACE
+
+#endif

--- a/src/QtAVPlayer/qavvideoframe.cpp
+++ b/src/QtAVPlayer/qavvideoframe.cpp
@@ -475,6 +475,7 @@ QAVVideoFrame::operator QVideoFrame() const
             if (result.isMapped())
                 format = VideoFrame::Format_NV12;
             break;
+        case AV_PIX_FMT_CUDA:
         case AV_PIX_FMT_D3D11:
         case AV_PIX_FMT_VIDEOTOOLBOX:
         case AV_PIX_FMT_NV12:


### PR DESCRIPTION
Added `cuda` hw device, that is applied when cuda is available
```
h264 : supported hardware device contexts:
    cuda
    vaapi
    vdpau
```

but other device contexts failed to apply or not implemented.