### PR TITLE
Remove double \n in ffmpeg logs

### DIFF
--- a/src/QtAVPlayer/qavdemuxer.cpp
+++ b/src/QtAVPlayer/qavdemuxer.cpp
@@ -130,6 +130,12 @@ static void log_callback(void *ptr, int level, const char *fmt, va_list vl)
 
     av_log_format_line(ptr, level, fmt, vl, line, sizeof(line), &print_prefix);
 
+    /* Remove trailing newline */
+    size_t len = std::strlen(line);
+    if (len > 0 && line[len - 1] == '\n') {
+        line[len - 1] = '\0';
+    }
+
     /* Adapt it to Qt log format */
     switch(level)
     {

--- a/src/QtAVPlayer/qavdemuxer.cpp
+++ b/src/QtAVPlayer/qavdemuxer.cpp
@@ -46,6 +46,7 @@ extern "C" {
 #include <QSharedPointer>
 #include <QMutexLocker>
 #include <atomic>
+#include <cstring>
 #include <QDebug>
 
 extern "C" {


### PR DESCRIPTION
In this pull request I removed double \n in logs by deleting extra \n inside log callback (issue #626). There were two approaches:
1. Get QDebug instance and set different options to escape \n after every log;
2. Remove extra /n inside ffmpeg line if possible.

I chose the second approach.
 