### PR TITLE
Negotiate hw device context based on provided codec

### DIFF
--- a/src/QtAVPlayer/qavdemuxer.cpp
+++ b/src/QtAVPlayer/qavdemuxer.cpp
@@ -222,43 +222,60 @@ static int setup_video_codec(const QString &inputVideoCodec, const QAVStream &st
     if (videoCodec)
         codec.setCodec(videoCodec);
 
-    QList<QSharedPointer<QAVHWDevice>> devices;
+    // Implemented HW devices
+    QMap<AVHWDeviceType, QSharedPointer<QAVHWDevice>> devices;
+    // Ordered supported devices
+    QList<AVHWDeviceType> preferredDevices;
     QAVDictionaryHolder opts;
     Q_UNUSED(opts);
 
 #if defined(QT_AVPLAYER_VA_X11) && QT_CONFIG(opengl)
-    devices.append(QSharedPointer<QAVHWDevice>(new QAVHWDevice_VAAPI_X11_GLX));
+    devices[AV_HWDEVICE_TYPE_VAAPI].reset(new QAVHWDevice_VAAPI_X11_GLX);
+    preferredDevices.push_back(AV_HWDEVICE_TYPE_VAAPI);
     av_dict_set(&opts.dict, "connection_type", "x11", 0);
 #endif
 #if defined(QT_AVPLAYER_VDPAU)
-    devices.append(QSharedPointer<QAVHWDevice>(new QAVHWDevice_VDPAU));
+    devices[AV_HWDEVICE_TYPE_VDPAU].reset(new QAVHWDevice_VDPAU);
+    preferredDevices.push_back(AV_HWDEVICE_TYPE_VDPAU);
 #endif
 #if defined(QT_AVPLAYER_VA_DRM) && QT_CONFIG(egl)
-    devices.append(QSharedPointer<QAVHWDevice>(new QAVHWDevice_VAAPI_DRM_EGL));
+    devices[AV_HWDEVICE_TYPE_VAAPI].reset(new QAVHWDevice_VAAPI_DRM_EGL);
+    preferredDevices.push_back(AV_HWDEVICE_TYPE_VAAPI);
 #endif
 #if defined(Q_OS_MACOS) || defined(Q_OS_IOS)
-    devices.append(QSharedPointer<QAVHWDevice>(new QAVHWDevice_VideoToolbox));
+    devices[AV_HWDEVICE_TYPE_VIDEOTOOLBOX].reset(new QAVHWDevice_VideoToolbox);
+    preferredDevices.push_back(AV_HWDEVICE_TYPE_VIDEOTOOLBOX);
 #endif
 #if defined(Q_OS_WIN)
-    devices.append(QSharedPointer<QAVHWDevice>(new QAVHWDevice_D3D11));
+    devices[AV_HWDEVICE_TYPE_D3D11VA].reset(new QAVHWDevice_D3D11);
+    preferredDevices.push_back(AV_HWDEVICE_TYPE_D3D11VA);
 #endif
 #if defined(Q_OS_ANDROID)
-    devices.append(QSharedPointer<QAVHWDevice>(new QAVHWDevice_MediaCodec));
+    devices[AV_HWDEVICE_TYPE_MEDIACODEC].reset(new QAVHWDevice_MediaCodec);
+    preferredDevices.push_back(AV_HWDEVICE_TYPE_MEDIACODEC);
     if (!ignoreHW && !codec.codec())
         codec.setCodec(avcodec_find_decoder_by_name("h264_mediacodec"));
     auto vm = QtAndroidPrivate::javaVM();
     av_jni_set_java_vm(vm, NULL);
 #endif
 #if defined(QT_AVPLAYER_CUDA)
-    devices.append(QSharedPointer<QAVHWDevice>(new QAVHWDevice_CUDA));
+    devices[AV_HWDEVICE_TYPE_CUDA].reset(new QAVHWDevice_CUDA);
+    preferredDevices.push_back(AV_HWDEVICE_TYPE_CUDA);
 #endif
 
     if (!ignoreHW) {
+        if (videoCodec) {
+            // Negotiate the devices from the video codec
+            preferredDevices = QAVVideoCodec::supportedHWDevices(videoCodec);
+        }
         AVBufferRef *hw_device_ctx = nullptr;
-        for (auto &device : devices) {
+        for (auto &supported : preferredDevices) {
+            auto it = devices.find(supported);
+            if (it == devices.end())
+                continue;
+            auto device = *it;
             auto deviceName = av_hwdevice_get_type_name(device->type());
-            if (av_hwdevice_ctx_create(&hw_device_ctx, device->type(), nullptr, opts.dict, 0)
-                >= 0) {
+            if (av_hwdevice_ctx_create(&hw_device_ctx, device->type(), nullptr, opts.dict, 0) >= 0) {
                 qDebug() << "[" << streamInfo.title << "] Using" << deviceName << "hardware device context";
                 codec.avctx()->hw_device_ctx = hw_device_ctx;
                 codec.avctx()->pix_fmt = device->format();

--- a/src/QtAVPlayer/qavvideocodec.cpp
+++ b/src/QtAVPlayer/qavvideocodec.cpp
@@ -1,5 +1,5 @@
 /***************************************************************
- * Copyright (C) 2020, 2025, Val Doroshchuk <valbok@gmail.com> *
+ * Copyright (C) 2020, 2026, Val Doroshchuk <valbok@gmail.com> *
  *                                                             *
  * This file is part of QtAVPlayer.                            *
  * Free Qt Media Player based on FFmpeg.                       *
@@ -55,21 +55,25 @@ static bool isSoftwarePixelFormat(AVPixelFormat from)
     }
 }
 
-static AVPixelFormat negotiate_pixel_format(AVCodecContext *c, const AVPixelFormat *f)
+QList<AVHWDeviceType> QAVVideoCodec::supportedHWDevices(const AVCodec *c)
 {
-    auto d = reinterpret_cast<QAVVideoCodecPrivate *>(c->opaque);
-
     QList<AVHWDeviceType> supported;
 #if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(58, 0, 0)
     for (int i = 0;; ++i) {
-        const AVCodecHWConfig *config = avcodec_get_hw_config(c->codec, i);
+        const AVCodecHWConfig *config = avcodec_get_hw_config(c, i);
         if (!config)
             break;
-
         if (config->methods & AV_CODEC_HW_CONFIG_METHOD_HW_DEVICE_CTX)
             supported.append(config->device_type);
     }
+#endif
+    return supported;
+}
 
+static AVPixelFormat negotiate_pixel_format(AVCodecContext *c, const AVPixelFormat *f)
+{
+    auto d = reinterpret_cast<QAVVideoCodecPrivate *>(c->opaque);
+    auto supported = QAVVideoCodec::supportedHWDevices(c->codec);
     if (!supported.isEmpty()) {
         qDebug() << c->codec->name << ": supported hardware device contexts:";
         for (auto a: supported)
@@ -77,7 +81,6 @@ static AVPixelFormat negotiate_pixel_format(AVCodecContext *c, const AVPixelForm
     } else {
         qWarning() << "None of the hardware accelerations are supported";
     }
-#endif
 
     QList<AVPixelFormat> softwareFormats;
     QList<AVPixelFormat> hardwareFormats;

--- a/src/QtAVPlayer/qavvideocodec_p.h
+++ b/src/QtAVPlayer/qavvideocodec_p.h
@@ -1,5 +1,5 @@
 /***************************************************************
- * Copyright (C) 2020, 2025, Val Doroshchuk <valbok@gmail.com> *
+ * Copyright (C) 2020, 2026, Val Doroshchuk <valbok@gmail.com> *
  *                                                             *
  * This file is part of QtAVPlayer.                            *
  * Free Qt Media Player based on FFmpeg.                       *
@@ -21,6 +21,10 @@
 
 #include "qavframecodec_p.h"
 
+extern "C" {
+#include <libavutil/hwcontext.h>
+}
+
 QT_BEGIN_NAMESPACE
 
 class QAVVideoCodecPrivate;
@@ -33,6 +37,8 @@ public:
 
     void setDevice(const QSharedPointer<QAVHWDevice> &d);
     QAVHWDevice *device() const;
+
+    static QList<AVHWDeviceType> supportedHWDevices(const AVCodec *c);
 
 private:
     Q_DISABLE_COPY(QAVVideoCodec)

--- a/tests/auto/integration/qavdemuxer/tst_qavdemuxer.cpp
+++ b/tests/auto/integration/qavdemuxer/tst_qavdemuxer.cpp
@@ -451,6 +451,13 @@ void tst_QAVDemuxer::videoCodecs()
     d.unload();
     d.setInputVideoCodec("software");
     QVERIFY(d.load(file.absoluteFilePath()) >= 0);
+#if defined(QT_AVPLAYER_CUDA)
+    if (codecs.contains("h264_cuvid")) {
+        d.unload();
+        d.setInputVideoCodec("h264_cuvid");
+        QVERIFY(d.load(file.absoluteFilePath()) >= 0);
+    }
+#endif
 }
 
 void tst_QAVDemuxer::inputOptions()


### PR DESCRIPTION
Currently the default hw device context is instantiated regardless about the codec. F.e. `vaapi`/`vdpau` for Linux, `d3d11va` for Windows, etc
When the codec is opened, it tries to use selected `hw_device`.
When the video codec is passed, f.e. `h264_cuvid`, it supports only `cuda` hw device, so using `vaapi` would fail and it will fall back to software based `nv12`.

So the hw device context should be based on selected codec, not on the platform itself.

Now If the codec is requested, it will try to negotiate hw device context from supported codec's hw devices,
`h264_cuvid` should use `cuda` hw device context type.
