### PR TITLE
Introduce hw devices for filters

### DIFF
--- a/src/QtAVPlayer/qavfiltergraph_p.h
+++ b/src/QtAVPlayer/qavfiltergraph_p.h
@@ -33,7 +33,6 @@
 QT_BEGIN_NAMESPACE
 
 class QAVFilterGraphPrivate;
-class QAVDemuxer;
 class Q_AVPLAYER_EXPORT QAVFilterGraph
 {
 public:

--- a/src/QtAVPlayer/qavhwdevice_cuda.cpp
+++ b/src/QtAVPlayer/qavhwdevice_cuda.cpp
@@ -7,12 +7,30 @@
 
 #include "qavhwdevice_cuda_p.h"
 #include "qavvideobuffer_gpu_p.h"
+#include <QDebug>
 
 extern "C" {
 #include <libavutil/pixdesc.h>
+#include <libavcodec/avcodec.h>
 }
 
 QT_BEGIN_NAMESPACE
+
+void QAVHWDevice_CUDA::init(AVCodecContext *avctx)
+{
+    AVBufferRef *frames_ref = av_hwframe_ctx_alloc(avctx->hw_device_ctx);
+    AVHWFramesContext *frames_ctx = (AVHWFramesContext*)(frames_ref->data);
+    frames_ctx->format    = AV_PIX_FMT_CUDA;
+    frames_ctx->sw_format = AV_PIX_FMT_NV12;
+    frames_ctx->width     = avctx->width;
+    frames_ctx->height    = avctx->height;
+    int ret = av_hwframe_ctx_init(frames_ref);
+    if (ret < 0) {
+        qWarning() << "Failed to initialize HW frames context:" << ret;
+        av_buffer_unref(&frames_ref);
+    }
+    avctx->hw_frames_ctx = frames_ref;
+}
 
 AVPixelFormat QAVHWDevice_CUDA::format() const
 {

--- a/src/QtAVPlayer/qavhwdevice_cuda_p.h
+++ b/src/QtAVPlayer/qavhwdevice_cuda_p.h
@@ -30,6 +30,7 @@ public:
     QAVHWDevice_CUDA() = default;
     ~QAVHWDevice_CUDA() = default;
 
+    void init(AVCodecContext *avctx) override;
     AVPixelFormat format() const override;
     AVHWDeviceType type() const override;
     QAVVideoBuffer *videoBuffer(const QAVVideoFrame &frame) const override;

--- a/src/QtAVPlayer/qavvideoinputfilter.cpp
+++ b/src/QtAVPlayer/qavvideoinputfilter.cpp
@@ -52,7 +52,8 @@ QAVVideoInputFilter::QAVVideoInputFilter(const QAVFrame &frame)
         auto codec = frame.stream().codec();
         auto avctx = codec ? codec->avctx() : nullptr;
         if (avctx && avctx->hw_frames_ctx) {
-            frm->format = avctx->pix_fmt; // hw accel pixel format like cuda
+            auto frames_ctx = (AVHWFramesContext*)(avctx->hw_frames_ctx->data);
+            frm->format = frames_ctx->format; // hw accel pixel format like cuda
             frm->hw_frames_ctx = av_buffer_ref(avctx->hw_frames_ctx);
         }
     }

--- a/src/QtAVPlayer/qavvideoinputfilter.cpp
+++ b/src/QtAVPlayer/qavvideoinputfilter.cpp
@@ -1,20 +1,21 @@
-/*********************************************************
- * Copyright (C) 2021, Val Doroshchuk <valbok@gmail.com> *
- *                                                       *
- * This file is part of QtAVPlayer.                      *
- * Free Qt Media Player based on FFmpeg.                 *
- *********************************************************/
+/***************************************************************
+ * Copyright (C) 2020, 2026, Val Doroshchuk <valbok@gmail.com> *
+ *                                                             *
+ * This file is part of QtAVPlayer.                            *
+ * Free Qt Media Player based on FFmpeg.                       *
+ ***************************************************************/
 
 #include "qavframe.h"
 #include "qavvideoinputfilter_p.h"
 #include "qavinoutfilter_p_p.h"
-#include "qavdemuxer_p.h"
+#include "qavcodec_p.h"
 #include <QDebug>
 
 extern "C" {
 #include <libavformat/avformat.h>
 #include <libavfilter/buffersrc.h>
 #include <libavutil/bprint.h>
+#include <libavcodec/avcodec.h>
 }
 
 QT_BEGIN_NAMESPACE
@@ -44,9 +45,18 @@ QAVVideoInputFilter::QAVVideoInputFilter(const QAVFrame &frame)
     : QAVVideoInputFilter()
 {
     Q_D(QAVVideoInputFilter);
-    const auto & frm = frame.frame();
-    const auto & stream = frame.stream().stream();
-    d->format =  frm->format != AV_PIX_FMT_NONE ? AVPixelFormat(frm->format) : AVPixelFormat(stream->codecpar->format);
+    const auto &frm = frame.frame();
+    const auto &stream = frame.stream().stream();
+    // Use codec's hw frame ctx
+    if (!frm->hw_frames_ctx) {
+        auto codec = frame.stream().codec();
+        auto avctx = codec ? codec->avctx() : nullptr;
+        if (avctx && avctx->hw_frames_ctx) {
+            frm->format = avctx->pix_fmt; // hw accel pixel format like cuda
+            frm->hw_frames_ctx = av_buffer_ref(avctx->hw_frames_ctx);
+        }
+    }
+    d->format = frm->format != AV_PIX_FMT_NONE ? AVPixelFormat(frm->format) : AVPixelFormat(stream->codecpar->format);
     d->width = frm->width ? frm->width : stream->codecpar->width;
     d->height = frm->height ? frm->height : stream->codecpar->height;
     d->sample_aspect_ratio = frm->sample_aspect_ratio.num && frm->sample_aspect_ratio.den ? frm->sample_aspect_ratio : stream->codecpar->sample_aspect_ratio;

--- a/tests/auto/integration/qavplayer/tst_qavplayer.cpp
+++ b/tests/auto/integration/qavplayer/tst_qavplayer.cpp
@@ -109,6 +109,7 @@ private slots:
     void muxerFilters();
     void muxerMultiSourceFrames();
     void framesAfterPlayerDestroyed();
+    void scaleHW();
 };
 
 void tst_QAVPlayer::initTestCase()
@@ -3591,6 +3592,24 @@ void tst_QAVPlayer::framesAfterPlayerDestroyed()
     QTRY_COMPARE(p->mediaStatus(), QAVPlayer::LoadedMedia);
     // Destroy the player but the frame could be still active
     p = nullptr;
+}
+
+void tst_QAVPlayer::scaleHW()
+{
+#if defined(QT_AVPLAYER_CUDA)
+    QAVPlayer p;
+    p.setSynced(false);
+    p.setInputVideoCodec("h264_cuvid");
+    p.setSource(QFileInfo(testData("small.mp4")).absoluteFilePath());
+    p.setFilter("scale_cuda=1920:1080");
+
+    QObject::connect(&p, &QAVPlayer::videoFrame, &p, [&](const QAVVideoFrame &f) {
+        QCOMPARE(f.size(), QSize(1920, 1080));
+    }, Qt::DirectConnection);
+
+    p.play();
+    QTRY_VERIFY(p.mediaStatus() == QAVPlayer::EndOfMedia);
+#endif
 }
 
 QTEST_MAIN(tst_QAVPlayer)


### PR DESCRIPTION
After #573 it was possible to use hw devices inside filters. But not all filters support hw device contexts.
Filters like scale_vaapi, scale_cuda supports but require its device context like `vaapi`, or `cuda`.

Since the filter graph is created after loading the source but before the decoding is started, it missed `hw_frames_ctx` to configure the filters using proper `hw_device_ctx`. 

Now fixed the filters to use codec's already created and initied `hw_frames_ctx`.