### PR TITLE
Apply filters after hw_frames_ctx is negotiated

### DIFF
--- a/src/QtAVPlayer/qavplayer.cpp
+++ b/src/QtAVPlayer/qavplayer.cpp
@@ -510,6 +510,7 @@ bool QAVPlayerPrivate::applyFilters(const QAVFrame &frame)
     QStringList descs;
     {
         QMutexLocker locker(&stateMutex);
+        // Don't continue frames on error
         if (error == QAVPlayer::FilterError)
             return false;
         descs = filterDescs;
@@ -527,8 +528,6 @@ bool QAVPlayerPrivate::applyFilters(const QAVFrame &frame)
         return false;
     }
     resetFilters = false;
-    videoQueue.clearFrames();
-    audioQueue.clearFrames();
     if (currentError() == QAVPlayer::FilterError)
         setMediaStatus(QAVPlayer::LoadedMedia);
     return true;

--- a/src/QtAVPlayer/qavplayer.cpp
+++ b/src/QtAVPlayer/qavplayer.cpp
@@ -1341,7 +1341,7 @@ void QAVPlayer::setBitstreamFilter(const QString &desc)
     int ret = d->demuxer.applyBitstreamFilter(desc);
     Q_EMIT bitstreamFilterChanged(desc);
     if (ret < 0)
-        d->setError(QAVPlayer::FilterError, QLatin1String("Could not parse bitstream filter desc: ") + err_str(ret));
+        d->setError(QAVPlayer::BitstreamFilterError, QLatin1String("Could not parse bitstream filter desc: ") + err_str(ret));
 }
 
 QString QAVPlayer::bitstreamFilter() const
@@ -1531,6 +1531,8 @@ QDebug operator<<(QDebug dbg, QAVPlayer::Error err)
             return dbg << "ResourceError";
         case QAVPlayer::FilterError:
             return dbg << "FilterError";
+        case QAVPlayer::BitstreamFilterError:
+            return dbg << "BitstreamFilterError";
         default:
             return dbg << QString(QLatin1String("UserType(%1)" )).arg(int(err)).toLatin1().constData();
     }

--- a/src/QtAVPlayer/qavplayer.cpp
+++ b/src/QtAVPlayer/qavplayer.cpp
@@ -507,11 +507,11 @@ bool QAVPlayerPrivate::applyFilters(const QAVFrame &frame)
 {
     if (!resetFilters)
         return true;
-    if (currentError() == QAVPlayer::FilterError)
-        return false;
     QStringList descs;
     {
         QMutexLocker locker(&stateMutex);
+        if (error == QAVPlayer::FilterError)
+            return false;
         descs = filterDescs;
     }
     qCDebug(lcAVPlayer) << __FUNCTION__ << ":" << filters.filterDescs() << "->" << descs;

--- a/src/QtAVPlayer/qavplayer.cpp
+++ b/src/QtAVPlayer/qavplayer.cpp
@@ -496,14 +496,19 @@ void QAVPlayerPrivate::wait(bool v)
 void QAVPlayerPrivate::applyFilters()
 {
     // Re-apply filters on error
-    if (currentError() == QAVPlayer::FilterError)
+    QMutexLocker locker(&stateMutex);
+    if (error == QAVPlayer::FilterError) {
         resetFilters = true;
+        error = QAVPlayer::NoError;
+    }
 }
 
 bool QAVPlayerPrivate::applyFilters(const QAVFrame &frame)
 {
     if (!resetFilters)
         return true;
+    if (currentError() == QAVPlayer::FilterError)
+        return false;
     QStringList descs;
     {
         QMutexLocker locker(&stateMutex);

--- a/src/QtAVPlayer/qavplayer.cpp
+++ b/src/QtAVPlayer/qavplayer.cpp
@@ -1142,9 +1142,9 @@ void QAVPlayer::play()
         }
         d->setPendingMediaStatus(PlayingMedia);
     }
-    d->wait(false);
     if (mediaStatus() != QAVPlayer::NoMedia)
         d->applyFilters();
+    d->wait(false);
 }
 
 void QAVPlayer::pause()
@@ -1160,12 +1160,12 @@ void QAVPlayer::pause()
             seek(0);
         }
         d->setPendingMediaStatus(PausingMedia);
+        if (mediaStatus() != QAVPlayer::NoMedia)
+            d->applyFilters();
         d->wait(false);
     } else {
         d->wait(true);
     }
-    if (mediaStatus() != QAVPlayer::NoMedia)
-        d->applyFilters();
 }
 
 void QAVPlayer::stop()
@@ -1177,12 +1177,12 @@ void QAVPlayer::stop()
     qCDebug(lcAVPlayer) << __FUNCTION__;
     if (d->setState(QAVPlayer::StoppedState)) {
         d->setPendingMediaStatus(StoppingMedia);
+        if (mediaStatus() != QAVPlayer::NoMedia)
+            d->applyFilters();
         d->wait(false);
     } else {
         d->wait(true);
     }
-    if (mediaStatus() != QAVPlayer::NoMedia)
-        d->applyFilters();
 }
 
 void QAVPlayer::stepForward()
@@ -1198,9 +1198,9 @@ void QAVPlayer::stepForward()
         seek(0);
     }
     d->setPendingMediaStatus(SteppingMedia);
-    d->wait(false);
     if (mediaStatus() != QAVPlayer::NoMedia)
         d->applyFilters();
+    d->wait(false);
 }
 
 void QAVPlayer::stepBackward()
@@ -1214,9 +1214,9 @@ void QAVPlayer::stepBackward()
     const qint64 pos = d->pts() > 0 ? (d->pts() - videoFrameRate()) * 1000 : duration();
     seek(pos);
     d->setPendingMediaStatus(SteppingMedia);
-    d->wait(false);
     if (mediaStatus() != QAVPlayer::NoMedia)
         d->applyFilters();
+    d->wait(false);
 }
 
 bool QAVPlayer::isSeekable() const
@@ -1238,9 +1238,9 @@ void QAVPlayer::seek(qint64 pos)
     }
 
     d->setPendingMediaStatus(SeekingMedia);
-    d->wait(false);
     if (mediaStatus() != QAVPlayer::NoMedia)
         d->applyFilters();
+    d->wait(false);
 }
 
 qint64 QAVPlayer::duration() const

--- a/src/QtAVPlayer/qavplayer.cpp
+++ b/src/QtAVPlayer/qavplayer.cpp
@@ -72,7 +72,7 @@ public:
     void setPts(double v);
     double pts() const;
     void applyFilters();
-    void applyFilters(bool reset, const QAVFrame &frame);
+    bool applyFilters(const QAVFrame &frame);
     void resetMuxer();
 
     void terminate();
@@ -157,10 +157,13 @@ public:
     mutable QMutex waitMutex;
     QWaitCondition waitCond;
     bool eof = false;
-    std::atomic_bool startDemuxing {false};
+    std::atomic_bool startDemuxing{false};
 
     QList<QString> filterDescs;
     QAVFilters filters;
+    // If set, means it requires to recreate filters using current filterDescs.
+    // It is done on doPlay threads.
+    std::atomic_bool resetFilters{false};
 };
 
 static QString err_str(int err)
@@ -489,29 +492,40 @@ void QAVPlayerPrivate::wait(bool v)
 
 void QAVPlayerPrivate::applyFilters()
 {
-    applyFilters(false, {});
+    // Re-apply filters on error
+    if (currentError() == QAVPlayer::FilterError)
+        resetFilters = true;
+    applyFilters({});
 }
 
-void QAVPlayerPrivate::applyFilters(bool reset, const QAVFrame &frame)
+bool QAVPlayerPrivate::applyFilters(const QAVFrame &frame)
 {
-    if ((filterDescs == filters.filterDescs()) && !reset)
-        return;
-    qCDebug(lcAVPlayer) << __FUNCTION__ << ":" << filters.filterDescs() << "->" << filterDescs << "reset:" << reset;
+    if (!resetFilters)
+        return true;
+    QStringList descs;
+    {
+        QMutexLocker locker(&stateMutex);
+        descs = filterDescs;
+    }
+    qCDebug(lcAVPlayer) << __FUNCTION__ << ":" << filters.filterDescs() << "->" << descs;
     const auto videoStreams = demuxer.currentVideoStreams();
     const auto audioStreams = demuxer.currentAudioStreams();
     int ret = filters.createFilters(
-        filterDescs,
+        descs,
         frame,
         !videoStreams.isEmpty() ? videoStreams.first() : QAVStream(),
         !audioStreams.isEmpty() ? audioStreams.first() : QAVStream());
+    // Don't repeat on error
+    resetFilters = false;
     if (ret < 0) {
         setError(QAVPlayer::FilterError, QLatin1String("Could not create filters: ") + err_str(ret));
-        return;
+        return false;
     }
     videoQueue.clearFrames();
     audioQueue.clearFrames();
-    if (error == QAVPlayer::FilterError)
+    if (currentError() == QAVPlayer::FilterError)
         setMediaStatus(QAVPlayer::LoadedMedia);
+    return true;
 }
 
 void QAVPlayerPrivate::resetMuxer()
@@ -543,7 +557,10 @@ void QAVPlayerPrivate::doLoad()
         return;
     }
 
-    applyFilters(true, {});
+    // Since some video filters require hw_frames_ctx available,
+    // the parsing of the filters here would fail in case when get_format might be not called yet.
+    // This schedules the parsing after the packets are already decoded.
+    resetFilters = true;
     resetMuxer();
     dispatch([this]() -> void {
         qCDebug(lcAVPlayer) << "[" << url << "]: Loaded, seekable:" << demuxer.seekable() << ", duration:" << demuxer.duration();
@@ -613,7 +630,8 @@ void QAVPlayerPrivate::doDemux()
                     qCDebug(lcAVPlayer) << "Flush codec buffers";
                     demuxer.flushCodecBuffers();
                     qCDebug(lcAVPlayer) << "Reset filters";
-                    applyFilters(true, {});
+                    resetFilters = true;
+                    applyFilters({});
                     qCDebug(lcAVPlayer) << "Start reading packets from" << pos * 1000;
                 } else {
                     qWarning() << "Could not seek:" << ret << ":" << err_str(ret);
@@ -749,8 +767,21 @@ void QAVPlayerPrivate::doPlayStep(
     // 2. Filter decoded frame
     QList<QAVFrame> filteredFrames;
     bool nextFrame = false;
-    if (decodedFrame)
+    if (decodedFrame) {
+        // Create filters if not yet created.
+        // Filters should be applied after all codecs are negotiated
+        // and all hw devices are initialized.
+        // Filters should be applied after get_format() callback is called in the video codecs.
+        if (master) {
+            if (!applyFilters(decodedFrame))
+                return;
+        } else {
+            // Don't proceed frames if filters are pending
+            if (resetFilters)
+                return;
+        }
         ret = filters.write(queue.mediaType(), decodedFrame);
+    }
     if (ret >= 0 || ret == AVERROR(EAGAIN))
         ret = filters.read(queue.mediaType(), decodedFrame, filteredFrames);
     if (ret < 0 && ret != AVERROR(EAGAIN)) {
@@ -760,8 +791,10 @@ void QAVPlayerPrivate::doPlayStep(
             setError(QAVPlayer::FilterError, err_str(ret));
             return;
         }
-        applyFilters(true, decodedFrame);
+        resetFilters = true;
+        applyFilters(decodedFrame);
     } else {
+        // There EAGAIN means try next one
         nextFrame = true;
     }
 
@@ -1267,6 +1300,7 @@ void QAVPlayer::setFilter(const QString &desc)
             d->filterDescs.clear();
         else
             d->filterDescs = {desc};
+        d->resetFilters = true;
     }
 
     Q_EMIT filtersChanged({desc});
@@ -1281,6 +1315,7 @@ void QAVPlayer::setFilters(const QList<QString> &filters)
         QMutexLocker locker(&d->stateMutex);
         qCDebug(lcAVPlayer) << __FUNCTION__ << ":" << d->filterDescs << "->" << filters;
         d->filterDescs = filters;
+        d->resetFilters = true;
     }
 
     Q_EMIT filtersChanged(filters);

--- a/src/QtAVPlayer/qavplayer.cpp
+++ b/src/QtAVPlayer/qavplayer.cpp
@@ -359,6 +359,9 @@ void QAVPlayerPrivate::terminate()
 void QAVPlayerPrivate::step(bool hasFrame)
 {
     QMutexLocker locker(&stateMutex);
+    // Don't proceed frame if there is an error or pending filters
+    if (error == QAVPlayer::FilterError || resetFilters)
+        hasFrame = false;
     while (!pendingMediaStatuses.isEmpty()) {
         auto status = pendingMediaStatuses.first();
         locker.unlock();
@@ -495,7 +498,6 @@ void QAVPlayerPrivate::applyFilters()
     // Re-apply filters on error
     if (currentError() == QAVPlayer::FilterError)
         resetFilters = true;
-    applyFilters({});
 }
 
 bool QAVPlayerPrivate::applyFilters(const QAVFrame &frame)
@@ -1304,8 +1306,6 @@ void QAVPlayer::setFilter(const QString &desc)
     }
 
     Q_EMIT filtersChanged({desc});
-    if (mediaStatus() != QAVPlayer::NoMedia)
-        d->applyFilters();
 }
 
 void QAVPlayer::setFilters(const QList<QString> &filters)
@@ -1319,8 +1319,6 @@ void QAVPlayer::setFilters(const QList<QString> &filters)
     }
 
     Q_EMIT filtersChanged(filters);
-    if (mediaStatus() != QAVPlayer::NoMedia)
-        d->applyFilters();
 }
 
 QList<QString> QAVPlayer::filters() const

--- a/src/QtAVPlayer/qavplayer.cpp
+++ b/src/QtAVPlayer/qavplayer.cpp
@@ -517,12 +517,11 @@ bool QAVPlayerPrivate::applyFilters(const QAVFrame &frame)
         frame,
         !videoStreams.isEmpty() ? videoStreams.first() : QAVStream(),
         !audioStreams.isEmpty() ? audioStreams.first() : QAVStream());
-    // Don't repeat on error
-    resetFilters = false;
     if (ret < 0) {
         setError(QAVPlayer::FilterError, QLatin1String("Could not create filters: ") + err_str(ret));
         return false;
     }
+    resetFilters = false;
     videoQueue.clearFrames();
     audioQueue.clearFrames();
     if (currentError() == QAVPlayer::FilterError)

--- a/src/QtAVPlayer/qavplayer.h
+++ b/src/QtAVPlayer/qavplayer.h
@@ -48,7 +48,8 @@ public:
     {
         NoError,
         ResourceError,
-        FilterError
+        FilterError,
+        BitstreamFilterError
     };
 
     QAVPlayer(QObject *parent = nullptr);

--- a/tests/auto/integration/qavplayer/tst_qavplayer.cpp
+++ b/tests/auto/integration/qavplayer/tst_qavplayer.cpp
@@ -2218,10 +2218,10 @@ void tst_QAVPlayer::lastFrame()
 
 void tst_QAVPlayer::configureFilter()
 {
-    qputenv("QT_AVPLAYER_NO_HWDEVICE", "1");
     QAVPlayer p;
 
     QFileInfo file(testData("small.mp4"));
+    p.setInputVideoCodec("software");
     p.setSource(file.absoluteFilePath());
     QSignalSpy spy(&p, &QAVPlayer::filtersChanged);
     QSignalSpy spyErrorOccurred(&p, &QAVPlayer::errorOccurred);
@@ -2931,9 +2931,9 @@ void tst_QAVPlayer::changeFormat()
 
 void tst_QAVPlayer::filterName()
 {
-    qputenv("QT_AVPLAYER_NO_HWDEVICE", "1");
     QAVPlayer p;
     QFileInfo file(testData("small.mp4"));
+    p.setInputVideoCodec("software");
     p.setSource(file.absoluteFilePath());
     p.setFilter("scale=iw/2:-1");
     QSet<QString> set;
@@ -2973,9 +2973,9 @@ void tst_QAVPlayer::filterName()
 
 void tst_QAVPlayer::filterNameStep()
 {
-    qputenv("QT_AVPLAYER_NO_HWDEVICE", "1");
     QAVPlayer p;
     QFileInfo file(testData("small.mp4"));
+    p.setInputVideoCodec("software");
     p.setSource(file.absoluteFilePath());
     p.setFilter("[0:v]split=3[in1][in2][in3];[in1]boxblur[out1];[in2]negate[out2];[in3]scale=iw/2:-1[out3]");
     QSet<QString> set;
@@ -3040,9 +3040,9 @@ void tst_QAVPlayer::filterNameStep()
 
 void tst_QAVPlayer::audioVideoFilter()
 {
-    qputenv("QT_AVPLAYER_NO_HWDEVICE", "1");
     QAVPlayer p;
     QFileInfo file(testData("test.mkv"));
+    p.setInputVideoCodec("software");
     p.setSource(file.absoluteFilePath());
     p.setFilter("ahistogram=dmode=separate:rheight=0:s=360x1:r=32,transpose=2,tile=layout=512x1,format=rgb24 [panel_4]");
 
@@ -3062,9 +3062,9 @@ void tst_QAVPlayer::audioVideoFilter()
 
 void tst_QAVPlayer::audioFilterVideoFrames()
 {
-    qputenv("QT_AVPLAYER_NO_HWDEVICE", "1");
     QAVPlayer p;
     QFileInfo file(testData("test.mkv"));
+    p.setInputVideoCodec("software");
     p.setSource(file.absoluteFilePath());
     p.setFilter("aformat=sample_fmts=flt|fltp,astats=metadata=1:reset=1:length=0.4,aphasemeter=video=0,ebur128=metadata=1,aformat=sample_fmts=flt|fltp");
 
@@ -3087,9 +3087,9 @@ void tst_QAVPlayer::audioFilterVideoFrames()
 
 void tst_QAVPlayer::multipleFilters()
 {
-    qputenv("QT_AVPLAYER_NO_HWDEVICE", "1");
     QAVPlayer p;
     QFileInfo file(testData("test.mkv"));
+    p.setInputVideoCodec("software");
     p.setSource(file.absoluteFilePath());
     QList<QString> filters = {
         "signalstats=stat=tout+vrep+brng [stats]",
@@ -3142,9 +3142,9 @@ void tst_QAVPlayer::multipleFilters()
 
 void tst_QAVPlayer::multipleAudioVideoFilters()
 {
-    qputenv("QT_AVPLAYER_NO_HWDEVICE", "1");
     QAVPlayer p;
     QFileInfo file(testData("test_5beeps.mkv"));
+    p.setInputVideoCodec("software");
     p.setSource(file.absoluteFilePath());
     QList<QString> filters = {
         "signalstats=stat=tout+vrep+brng [stats]",
@@ -3211,9 +3211,9 @@ void tst_QAVPlayer::inputVideoCodec()
 
 void tst_QAVPlayer::flushFilters()
 {
-    qputenv("QT_AVPLAYER_NO_HWDEVICE", "1");
     QAVPlayer p;
     QFileInfo file(testData("BAVC1010958_DV000107.dv"));
+    p.setInputVideoCodec("software");
     p.setSource(file.absoluteFilePath());
     p.setFilter("scale,format=rgb32,crop=1:ih:iw/2:0,tile=layout=512x1,setsar=1/1 [panel_0]");
     int framesCount = 0;

--- a/tests/auto/integration/qavplayer/tst_qavplayer.cpp
+++ b/tests/auto/integration/qavplayer/tst_qavplayer.cpp
@@ -2272,7 +2272,7 @@ void tst_QAVPlayer::configureFilter()
     p.stop();
     p.setFilter("wrong");
     QCOMPARE(p.filters(), {"wrong"});
-    QTRY_COMPARE(spyErrorOccurred.count(), 1);
+    QTRY_COMPARE(spyErrorOccurred.count(), 0);
 
     spyErrorOccurred.clear();
 
@@ -2304,13 +2304,13 @@ void tst_QAVPlayer::configureFilter()
     p.setFilter("wrong");
     QCOMPARE(p.filters(), {"wrong"});
     QTRY_COMPARE(spy.count(), 1);
-    QTRY_COMPARE(spyErrorOccurred.count(), 1);
-    QCOMPARE(p.state(), QAVPlayer::StoppedState);
+    QTRY_COMPARE(spyErrorOccurred.count(), 0);
+    QCOMPARE(p.state(), QAVPlayer::PausedState);
 
     spyErrorOccurred.clear();
 
     p.pause();
-    QTRY_COMPARE(spyErrorOccurred.count(), 1);
+    QTRY_COMPARE(spyErrorOccurred.count(), 0);
 
     spyErrorOccurred.clear();
 
@@ -2323,12 +2323,12 @@ void tst_QAVPlayer::configureFilter()
     p.setFilter("wrong2");
     QCOMPARE(p.filters(), {"wrong2"});
     QTRY_COMPARE(spy.count(), 1);
-    QTRY_COMPARE(spyErrorOccurred.count(), 1);
+    QTRY_COMPARE(spyErrorOccurred.count(), 0);
 
     spyErrorOccurred.clear();
 
     p.stop();
-    QCOMPARE(spyErrorOccurred.count(), 1);
+    QCOMPARE(spyErrorOccurred.count(), 0);
 
     spyErrorOccurred.clear();
 

--- a/tests/auto/integration/qavplayer/tst_qavplayer.cpp
+++ b/tests/auto/integration/qavplayer/tst_qavplayer.cpp
@@ -2361,6 +2361,7 @@ void tst_QAVPlayer::changeSourceFilter()
     QAVPlayer p;
 
     QFileInfo file1(testData("small.mp4"));
+    p.setInputVideoCodec("software");
     p.setSource(file1.absoluteFilePath());
     QSignalSpy spy(&p, &QAVPlayer::filtersChanged);
     QSignalSpy spyErrorOccurred(&p, &QAVPlayer::errorOccurred);
@@ -3596,20 +3597,31 @@ void tst_QAVPlayer::framesAfterPlayerDestroyed()
 
 void tst_QAVPlayer::scaleHW()
 {
-#if defined(QT_AVPLAYER_CUDA)
     QAVPlayer p;
     p.setSynced(false);
+    QSize size;
+#if defined(QT_AVPLAYER_CUDA)
     p.setInputVideoCodec("h264_cuvid");
-    p.setSource(QFileInfo(testData("small.mp4")).absoluteFilePath());
     p.setFilter("scale_cuda=1920:1080");
-
+    size = {1920, 1080};
+#endif
+#if defined(Q_OS_MACOS) || defined(Q_OS_IOS)
+    p.setFilter("scale_vt=1920:1080");
+    size = {1920, 1080};
+#endif
+#if defined(Q_OS_WIN) && 0
+    p.setFilter("scale_d3d11=1920:1080");
+    size = {1920, 1080};
+#endif
+    if (size.isEmpty())
+        return;
+    p.setSource(QFileInfo(testData("small.mp4")).absoluteFilePath());
     QObject::connect(&p, &QAVPlayer::videoFrame, &p, [&](const QAVVideoFrame &f) {
-        QCOMPARE(f.size(), QSize(1920, 1080));
+        QCOMPARE(f.size(), size);
     }, Qt::DirectConnection);
 
     p.play();
     QTRY_VERIFY(p.mediaStatus() == QAVPlayer::EndOfMedia);
-#endif
 }
 
 QTEST_MAIN(tst_QAVPlayer)

--- a/tests/auto/integration/qavplayer/tst_qavplayer.cpp
+++ b/tests/auto/integration/qavplayer/tst_qavplayer.cpp
@@ -2362,7 +2362,6 @@ void tst_QAVPlayer::changeSourceFilter()
 
     QFileInfo file1(testData("small.mp4"));
     p.setInputVideoCodec("software");
-    p.setSource(file1.absoluteFilePath());
     QSignalSpy spy(&p, &QAVPlayer::filtersChanged);
     QSignalSpy spyErrorOccurred(&p, &QAVPlayer::errorOccurred);
     QAVVideoFrame frame;
@@ -2370,6 +2369,7 @@ void tst_QAVPlayer::changeSourceFilter()
 
     const QString desc = "scale=iw/2:-1";
     p.setFilter(desc);
+    p.setSource(file1.absoluteFilePath());
     p.play();
     QTRY_VERIFY(frame);
     QCOMPARE(frame.size(), QSize(560 / 2, 320 / 2));
@@ -2448,7 +2448,6 @@ void tst_QAVPlayer::filter()
     QAVPlayer p;
 
     QFileInfo file(testData("dv25_pal__411_4-3_2ch_32k_bars_sine.dv"));
-    p.setSource(file.absoluteFilePath());
 
     QSignalSpy spyVideoFilterChanged(&p, &QAVPlayer::filtersChanged);
     QSignalSpy spyErrorOccurred(&p, &QAVPlayer::errorOccurred);
@@ -2456,6 +2455,7 @@ void tst_QAVPlayer::filter()
     QObject::connect(&p, &QAVPlayer::videoFrame, &p, [&](const QAVVideoFrame &f) { frame = f; });
 
     p.setFilter(filter);
+    p.setSource(file.absoluteFilePath());
     p.pause();
     QTRY_VERIFY_WITH_TIMEOUT(frame, 10000);
     QTRY_COMPARE(spyVideoFilterChanged.count(), 1);
@@ -2917,8 +2917,8 @@ void tst_QAVPlayer::changeFormat()
 {
     QAVPlayer p;
     QFileInfo file(testData("1.dv"));
-    p.setSource(file.absoluteFilePath());
     p.setFilter("[0:v]split=2[in1][in2];[in1]boxblur[out1];[in2]negate[out2]");
+    p.setSource(file.absoluteFilePath());
     QAVVideoFrame videoFrame;
     QObject::connect(&p, &QAVPlayer::videoFrame, &p, [&](const QAVVideoFrame &frame) {
         videoFrame = frame;
@@ -3145,6 +3145,7 @@ void tst_QAVPlayer::multipleAudioVideoFilters()
     QAVPlayer p;
     QFileInfo file(testData("test_5beeps.mkv"));
     p.setInputVideoCodec("software");
+    p.setFilters(filters);
     p.setSource(file.absoluteFilePath());
     QList<QString> filters = {
         "signalstats=stat=tout+vrep+brng [stats]",
@@ -3165,7 +3166,6 @@ void tst_QAVPlayer::multipleAudioVideoFilters()
     }, Qt::DirectConnection);
 
     p.setSynced(false);
-    p.setFilters(filters);
     p.play();
     QTRY_COMPARE_WITH_TIMEOUT(p.mediaStatus(), QAVPlayer::EndOfMedia, 15000);
     QVERIFY(framesCount.contains("stats"));
@@ -3214,8 +3214,8 @@ void tst_QAVPlayer::flushFilters()
     QAVPlayer p;
     QFileInfo file(testData("BAVC1010958_DV000107.dv"));
     p.setInputVideoCodec("software");
-    p.setSource(file.absoluteFilePath());
     p.setFilter("scale,format=rgb32,crop=1:ih:iw/2:0,tile=layout=512x1,setsar=1/1 [panel_0]");
+    p.setSource(file.absoluteFilePath());
     int framesCount = 0;
     QObject::connect(&p, &QAVPlayer::videoFrame, &p, [&](const QAVVideoFrame &) {
         ++framesCount;
@@ -3513,8 +3513,8 @@ void tst_QAVPlayer::muxerFilters()
     QAVMuxerFrames m;
     p.setSynced(false);
     p.setInputVideoCodec("software");
-    p.setSource(QFileInfo(testData("small.mp4")).absoluteFilePath());
     p.setFilter("curves=vintage");
+    p.setSource(QFileInfo(testData("small.mp4")).absoluteFilePath());
 
     QObject::connect(&p, &QAVPlayer::videoFrame, &p, [&](const QAVVideoFrame &f) {
         QVERIFY(m.write(f) < 0);

--- a/tests/auto/integration/qavplayer/tst_qavplayer.cpp
+++ b/tests/auto/integration/qavplayer/tst_qavplayer.cpp
@@ -2273,7 +2273,9 @@ void tst_QAVPlayer::configureFilter()
     p.setFilter("wrong");
     QCOMPARE(p.filters(), {"wrong"});
     QTRY_COMPARE(spyErrorOccurred.count(), 0);
+    QTRY_VERIFY(frame);
 
+    frame = QAVVideoFrame();
     spyErrorOccurred.clear();
 
     p.pause();
@@ -2285,7 +2287,6 @@ void tst_QAVPlayer::configureFilter()
     p.pause();
     QCOMPARE(p.filters(), {"wrong"});
     QTRY_COMPARE(spyErrorOccurred.count(), 1);
-    QVERIFY(!frame);
 
     spy.clear();
     spyErrorOccurred.clear();

--- a/tests/auto/integration/qavplayer/tst_qavplayer.cpp
+++ b/tests/auto/integration/qavplayer/tst_qavplayer.cpp
@@ -3607,11 +3607,11 @@ void tst_QAVPlayer::scaleHW()
 #endif
 #if defined(Q_OS_MACOS) || defined(Q_OS_IOS)
     p.setFilter("scale_vt=1920:1080");
-    size = {1920, 1080};
+    //size = {1920, 1080}; // TODO: ci could fail to initialize videotoolbox_vld
 #endif
-#if defined(Q_OS_WIN) && 0
+#if defined(Q_OS_WIN)
     p.setFilter("scale_d3d11=1920:1080");
-    size = {1920, 1080};
+    //size = {1920, 1080};
 #endif
     if (size.isEmpty())
         return;

--- a/tests/auto/integration/qavplayer/tst_qavplayer.cpp
+++ b/tests/auto/integration/qavplayer/tst_qavplayer.cpp
@@ -3418,9 +3418,9 @@ void tst_QAVPlayer::multiFilterInputs()
     QAVFrame frame;
     QObject::connect(&p, &QAVPlayer::videoFrame, &p, [&](const QAVVideoFrame &f) { frame = f; ++framesCount; }, Qt::DirectConnection);
 
+    p.setFilter(filter);
     p.setSource(file.absoluteFilePath());
     p.setSynced(false);
-    p.setFilter(filter);
     p.play();
 
     QTRY_COMPARE(p.mediaStatus(), QAVPlayer::EndOfMedia);

--- a/tests/auto/integration/qavplayer/tst_qavplayer.cpp
+++ b/tests/auto/integration/qavplayer/tst_qavplayer.cpp
@@ -3145,12 +3145,12 @@ void tst_QAVPlayer::multipleAudioVideoFilters()
     QAVPlayer p;
     QFileInfo file(testData("test_5beeps.mkv"));
     p.setInputVideoCodec("software");
-    p.setFilters(filters);
-    p.setSource(file.absoluteFilePath());
     QList<QString> filters = {
         "signalstats=stat=tout+vrep+brng [stats]",
         "aformat=sample_fmts=flt|fltp,astats=metadata=1:reset=1:length=0.4,aphasemeter=video=0,ebur128=metadata=1,aformat=sample_fmts=flt|fltp [audio]",
     };
+    p.setFilters(filters);
+    p.setSource(file.absoluteFilePath());
 
     QMap<QString, int> framesCount;
     QAVVideoFrame videoFrame;


### PR DESCRIPTION
Currently creation of the filters is done after all codecs are opened, which was considered as `LoadedMedia`, and before the demuxing and decoding are started.
This worked for software filters, but fails for some hwaccel filters like `scale_vt` which requires to decode first packet to negotiate `hw_frames_ctx`. 
Also `ffplay` and ffmpeg` decode packets before filters are created.

Fixed logic how filters are applied
1. If filters are set, it postpones the applying when first packet is decoded.
2. While filters are pending, no frames are sent to users. And frames are kept in the queue until the filters are applied.
3. Added `BitstreamFilterError` to say it is not `FilterError`
4. Fixed some tests since logic of applying has changed: Now filters are applied only when frames are being processed: on first pause(), or play(), or stepForward() or stepBackward().
Following does not apply filters anymore:
```
p.setSource(url);
p.setFilter(filter);
...
p.stop();
```
then no errors and no frames are sent.

Also setting filters after the source is loaded could miss some frames, that are already processed and sent. Then the filters should be set before the source.

