### PR TITLE
Introduce QAVMuxerFrames::outputVideoCodec

### DIFF
--- a/src/QtAVPlayer/qavmuxerframes.cpp
+++ b/src/QtAVPlayer/qavmuxerframes.cpp
@@ -34,6 +34,7 @@ public:
     {
     }
 
+    QString outputVideoCodec;
     QMap<int, QAVStream> encStreams;
     std::unique_ptr<QThread> workerThread;
     QList<QAVFrame> frames;
@@ -78,6 +79,20 @@ QAVMuxerFrames::~QAVMuxerFrames()
     reset(locker);
 }
 
+void QAVMuxerFrames::setOutputVideoCodec(const QString &name)
+{
+    Q_D(QAVMuxerFrames);
+    QMutexLocker locker(&d->mutex);
+    d->outputVideoCodec = name;
+}
+
+QString QAVMuxerFrames::outputVideoCodec() const
+{
+    Q_D(const QAVMuxerFrames);
+    QMutexLocker locker(&d->mutex);
+    return d->outputVideoCodec;
+}
+
 void QAVMuxerFrames::enqueue(const QAVFrame &frame)
 {
     Q_D(QAVMuxerFrames);
@@ -111,11 +126,26 @@ int QAVMuxerFrames::initStream(const QAVStream &stream, int index, AVStream *out
     Q_D(QAVMuxerFrames);
     auto in_stream = stream.stream();
     auto dec_ctx = stream.codec()->avctx();
-    // Transcoding to same codec
-    auto encoder = avcodec_find_encoder(dec_ctx->codec_id);
-    if (!encoder) {
-        qWarning() << "Encoder not found:" << stream.codec()->codec()->name;
-        return AVERROR_INVALIDDATA;
+    const AVCodec *encoder = nullptr;
+    switch (in_stream->codecpar->codec_type) {
+    case AVMEDIA_TYPE_VIDEO:
+        if (!d->outputVideoCodec.isEmpty()) {
+            qDebug() << "Loading: -vcodec" << d->outputVideoCodec;
+            encoder = avcodec_find_encoder_by_name(d->outputVideoCodec.toUtf8().constData());
+            if (!encoder) {
+                qWarning() << "Encoder not found:" << d->outputVideoCodec;
+                return AVERROR(EINVAL);
+            }
+            break;
+        }
+        [[fallthrough]];
+    default:
+        // Transcoding to same codec
+        encoder = avcodec_find_encoder(dec_ctx->codec_id);
+        if (!encoder) {
+            qWarning() << "Encoder not found:" << dec_ctx->codec_id;
+            return AVERROR(EINVAL);
+        }
     }
 
     AVCodecContext *enc_ctx = nullptr;
@@ -123,17 +153,20 @@ int QAVMuxerFrames::initStream(const QAVStream &stream, int index, AVStream *out
     int ret = 0;
     switch (dec_ctx->codec_type) {
     case AVMEDIA_TYPE_VIDEO:
-        // pix_fmt might be not supported by the encoder, f.e. vdpau
-        // so falling back to software pixel format
-        if (dec_ctx->sw_pix_fmt != AV_PIX_FMT_NONE)
-            dec_ctx->pix_fmt = dec_ctx->sw_pix_fmt;
         codec.reset(new QAVVideoCodec(encoder));
         enc_ctx = codec->avctx();
         enc_ctx->height = dec_ctx->height;
         enc_ctx->width = dec_ctx->width;
         enc_ctx->sample_aspect_ratio = dec_ctx->sample_aspect_ratio;
-        enc_ctx->pix_fmt = dec_ctx->pix_fmt;
+        // pix_fmt might be not supported by the encoder, f.e. vdpau
+        // so falling back to software pixel format
+        if (d->outputVideoCodec.isEmpty() && dec_ctx->sw_pix_fmt != AV_PIX_FMT_NONE)
+            enc_ctx->pix_fmt = dec_ctx->sw_pix_fmt;
+        else
+            enc_ctx->pix_fmt = dec_ctx->pix_fmt;
         enc_ctx->time_base = in_stream->time_base;
+        if (!d->outputVideoCodec.isEmpty() && dec_ctx->hw_frames_ctx)
+            enc_ctx->hw_frames_ctx = av_buffer_ref(dec_ctx->hw_frames_ctx);
         if (d->ctx->ctx()->oformat->flags & AVFMT_GLOBALHEADER)
             enc_ctx->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
         if (!codec->open(out_stream)) {

--- a/src/QtAVPlayer/qavmuxerframes.h
+++ b/src/QtAVPlayer/qavmuxerframes.h
@@ -22,6 +22,14 @@ public:
     QAVMuxerFrames();
     ~QAVMuxerFrames() override;
     
+    /**
+     * Sets desired output codec. E.g h264_nvenc for h264_cuvid decoder.
+     * Uses avcodec_find_encoder_by_name() internally.
+     * Should be called before load().
+     */
+    void setOutputVideoCodec(const QString &name);
+    QString outputVideoCodec() const;
+
     // Adds the frame to the queue
     void enqueue(const QAVFrame &frame);
 

--- a/tests/auto/integration/qavdemuxer/tst_qavdemuxer.cpp
+++ b/tests/auto/integration/qavdemuxer/tst_qavdemuxer.cpp
@@ -23,6 +23,7 @@
 
 extern "C" {
 #include <libavcodec/avcodec.h>
+#include <libavformat/avformat.h>
 }
 
 #ifndef TEST_DATA_DIR
@@ -60,6 +61,7 @@ private slots:
     void muxerWritePacketsFromMultiSources();
     void muxerWritePacketsFromDev();
     void muxerFramesCodecInfo();
+    void muxerFramesScaleHW();
 };
 
 void tst_QAVDemuxer::construction()
@@ -456,6 +458,10 @@ void tst_QAVDemuxer::videoCodecs()
         d.unload();
         d.setInputVideoCodec("h264_cuvid");
         QVERIFY(d.load(file.absoluteFilePath()) >= 0);
+        QVERIFY(!d.currentVideoStreams().isEmpty());
+        auto codec = d.currentVideoStreams()[0].codec();
+        QVERIFY(codec);
+        QCOMPARE(codec->avctx()->pix_fmt, AV_PIX_FMT_CUDA);
     }
 #endif
 }
@@ -892,6 +898,65 @@ void tst_QAVDemuxer::muxerFramesCodecInfo()
         QVERIFY(s.codec());
         QCOMPARE(s.codec()->size(), size);
     }
+}
+
+void tst_QAVDemuxer::muxerFramesScaleHW()
+{
+#if defined(QT_AVPLAYER_CUDA)
+    QFileInfo file(testData("small.mp4"));
+    QAVDemuxer d;
+
+    d.setInputVideoCodec("h264_cuvid");
+    QVERIFY(d.load(file.absoluteFilePath()) >= 0);
+    QVERIFY(!d.currentVideoStreams().isEmpty());
+    auto codec = d.currentVideoStreams()[0].codec();
+    QVERIFY(codec);
+    QCOMPARE(codec->avctx()->pix_fmt, AV_PIX_FMT_CUDA);
+    QVERIFY(!d.availableVideoStreams().isEmpty());
+    QSize size(128, 96);
+    for (auto &s : d.availableVideoStreams()) {
+        QVERIFY(s.codec());
+        QCOMPARE(s.codec()->size(), QSize(560, 320));
+        // It does not rescale, sets output size only
+        s.codec()->avctx()->width = size.width();
+        s.codec()->avctx()->height = size.height();
+        QVERIFY(s.codec()->size() == size);
+    }
+
+    QAVMuxerFrames m;
+    // Using software codec
+    QVERIFY(m.load(d.availableStreams(), "small.mkv") >= 0);
+    m.setOutputVideoCodec("notfound");
+    QVERIFY(m.load(d.availableStreams(), "small.mkv") < 0);
+
+    m.setOutputVideoCodec("h264_nvenc");
+    QCOMPARE(m.outputVideoCodec(), "h264_nvenc");
+    QVERIFY(m.load(d.availableStreams(), "small.mkv") >= 0);
+
+    QAVPacket p;
+    while (d.read(p) >= 0) {
+        QList<QAVFrame> fs;
+        QAVDemuxer::decode(p, fs);
+        if (fs.size()) {
+            QVERIFY(fs.size() == 1);
+            auto &f = fs[0];
+            QVERIFY(f);
+            if (f.stream().stream()->codecpar->codec_type == AVMEDIA_TYPE_VIDEO)
+                QCOMPARE(AVPixelFormat(f.frame()->format), AV_PIX_FMT_CUDA);
+            m.enqueue(f);
+        }
+    }
+    QTRY_VERIFY(m.size() == 0);
+    QVERIFY(m.flush() >= 0);
+    m.unload();
+    d.unload();
+    QVERIFY(d.load("small.mkv") >= 0);
+    QVERIFY(!d.availableVideoStreams().isEmpty());
+    for (auto &s : d.availableVideoStreams()) {
+        QVERIFY(s.codec());
+        QCOMPARE(s.codec()->size(), size);
+    }
+#endif
 }
 
 QTEST_MAIN(tst_QAVDemuxer)


### PR DESCRIPTION
If decoding is using hwaccel, f.e. cuda, for now `QAVMuxerFrames` still uses software codec (f.e. libx264) and `sw_pix_fmt` (f.e. nv12).

Added `QAVMuxerFrames::setOutputVideoCodec()` which forces to use desired encoder.
This allows to use hw encoders.

```
demuxer.setInputVideoCodec("h264_cuvid"); 
muxer.setOutputVideoCodec("h264_nvenc");
```