### PR TITLE
Introduce QAVMuxerFrames::EncoderStream

### DIFF
--- a/src/QtAVPlayer/qavmuxer.cpp
+++ b/src/QtAVPlayer/qavmuxer.cpp
@@ -98,6 +98,7 @@ int QAVMuxer::allocFormatContext(const QString &filename, Locker &)
 int QAVMuxer::writeHeader(Locker &)
 {
     Q_D(QAVMuxer);
+    av_dump_format(d->ctx->ctx(), 0, d->filename.toUtf8().constData(), 1);
     // Init muxer, write output file header
     int ret = avformat_write_header(d->ctx->ctx(), nullptr);
     if (ret < 0) {
@@ -108,37 +109,7 @@ int QAVMuxer::writeHeader(Locker &)
     return 0;
 }
 
-int QAVMuxer::load(const QList<QAVStream> &streams, const QString &filename)
-{
-    Q_D(QAVMuxer);
-    QMutexLocker locker(&d->mutex);
-    reset(locker);
-    int ret = allocFormatContext(filename, locker);
-    if (ret < 0)
-        return ret;
-    ret = initStreams(streams, locker);
-    if (ret < 0)
-        return ret;
-
-    init(locker);
-    return writeHeader(locker);
-}
-
-int QAVMuxer::initStreams(const QList<QAVStream> &streams, Locker &locker)
-{
-    Q_D(QAVMuxer);
-    int ret = 0;
-    for (int i = 0; i < streams.size(); ++i) {
-        auto &stream = streams[i];
-        ret = newOutputStream(stream, locker);
-        if (ret < 0)
-            return ret;
-    }
-    av_dump_format(d->ctx->ctx(), 0, d->filename.toUtf8().constData(), 1);
-    return 0;
-}
-
-int QAVMuxer::newOutputStream(const QAVStream &stream, Locker &locker)
+int QAVMuxer::newOutputStream(const QAVStream &stream, Locker &)
 {
     Q_D(QAVMuxer);
     auto codec = stream.codec();
@@ -156,9 +127,8 @@ int QAVMuxer::newOutputStream(const QAVStream &stream, Locker &locker)
         stream.codec()->codec()->name << ", codec_id" << dec_ctx->codec_id <<
         ", pix_fmt:" << dec_ctx->pix_fmt << (pix_fmt_desc ? pix_fmt_desc->name : "");
     auto i = d->ctx->ctx()->nb_streams - 1;
-    int ret = initStream(stream, i, d->ctx->ctx()->streams[i], locker);
     d->outputStreams[stream.stream()] = i;
-    return ret;
+    return 0;
 }
 
 int QAVMuxer::flush()

--- a/src/QtAVPlayer/qavmuxer.h
+++ b/src/QtAVPlayer/qavmuxer.h
@@ -31,9 +31,6 @@ public:
 
     virtual ~QAVMuxer();
 
-    // Loads the encoder based on parsed streams, format is negotiated from filename
-    int load(const QList<QAVStream> &streams, const QString &filename);
-
     // Stops and unloads the encoder
     void unload();
 
@@ -45,12 +42,9 @@ protected:
     QAVMuxer(QAVMuxerPrivate &d);
 
     int allocFormatContext(const QString &filename, Locker &);
-    int initStreams(const QList<QAVStream> &streams, Locker &);
     int newOutputStream(const QAVStream &stream, Locker &);
     int writeHeader(Locker &);
 
-    virtual void init(Locker &) = 0;
-    virtual int initStream(const QAVStream &stream, int index, AVStream *out_stream, Locker &) = 0;
     virtual int flushFrames(Locker &) = 0;
     virtual void reset(Locker &);
     void close(Locker &);

--- a/src/QtAVPlayer/qavmuxerframes.cpp
+++ b/src/QtAVPlayer/qavmuxerframes.cpp
@@ -66,36 +66,6 @@ void QAVMuxerFramesPrivate::doWork()
     }
 }
 
-QAVMuxerFrames::EncoderStream::EncoderStream(const QAVStream &stream)
-    : m_stream(stream)
-{
-}
-
-const QAVStream &QAVMuxerFrames::EncoderStream::stream() const
-{
-    return m_stream;
-}
-
-void QAVMuxerFrames::EncoderStream::setCodec(const QString &codec)
-{
-    m_codec = codec;
-}
-
-const QString &QAVMuxerFrames::EncoderStream::codec() const
-{
-    return m_codec;
-}
-
-void QAVMuxerFrames::EncoderStream::setSize(const QSize &size)
-{
-    m_size = size;
-}
-
-const QSize &QAVMuxerFrames::EncoderStream::size() const
-{
-    return m_size;
-}
-
 QAVMuxerFrames::QAVMuxerFrames()
     : QAVMuxer(*new QAVMuxerFramesPrivate(this))
 {
@@ -153,7 +123,7 @@ int QAVMuxerFrames::initStreams(const QList<EncoderStream> &streams, Locker &loc
     int ret = 0;
     for (int i = 0; i < streams.size(); ++i) {
         auto &stream = streams[i];
-        ret = newOutputStream(stream.stream(), locker);
+        ret = newOutputStream(stream.stream, locker);
         if (ret < 0)
             return ret;
         ret = initStream(stream, i, d->ctx->ctx()->streams[i], locker);
@@ -175,15 +145,15 @@ void QAVMuxerFrames::init(Locker &)
 int QAVMuxerFrames::initStream(const EncoderStream &encoderStream, int index, AVStream *out_stream, Locker &)
 {
     Q_D(QAVMuxerFrames);
-    const auto &stream = encoderStream.stream();
+    const auto &stream = encoderStream.stream;
     auto in_stream = stream.stream();
     auto dec_ctx = stream.codec()->avctx();
     const AVCodec *encoder = nullptr;
-    if (!encoderStream.codec().isEmpty()) {
-        qDebug() << "Loading encoder:" << encoderStream.codec();
-        encoder = avcodec_find_encoder_by_name(encoderStream.codec().toUtf8().constData());
+    if (!encoderStream.codec.isEmpty()) {
+        qDebug() << "Loading encoder:" << encoderStream.codec;
+        encoder = avcodec_find_encoder_by_name(encoderStream.codec.toUtf8().constData());
         if (!encoder) {
-            qWarning() << "Encoder not found:" << encoderStream.codec();
+            qWarning() << "Encoder not found:" << encoderStream.codec;
             return AVERROR(EINVAL);
         }
     } else {
@@ -202,9 +172,9 @@ int QAVMuxerFrames::initStream(const EncoderStream &encoderStream, int index, AV
     case AVMEDIA_TYPE_VIDEO:
         codec.reset(new QAVVideoCodec(encoder));
         enc_ctx = codec->avctx();
-        if (!encoderStream.size().isEmpty()) {
-            enc_ctx->height = encoderStream.size().height();
-            enc_ctx->width = encoderStream.size().width();
+        if (!encoderStream.size.isEmpty()) {
+            enc_ctx->height = encoderStream.size.height();
+            enc_ctx->width = encoderStream.size.width();
         } else {
             enc_ctx->height = dec_ctx->height;
             enc_ctx->width = dec_ctx->width;
@@ -212,12 +182,12 @@ int QAVMuxerFrames::initStream(const EncoderStream &encoderStream, int index, AV
         enc_ctx->sample_aspect_ratio = dec_ctx->sample_aspect_ratio;
         // pix_fmt might be not supported by the encoder, f.e. vdpau
         // so falling back to software pixel format
-        if (encoderStream.codec().isEmpty() && dec_ctx->sw_pix_fmt != AV_PIX_FMT_NONE)
+        if (encoderStream.codec.isEmpty() && dec_ctx->sw_pix_fmt != AV_PIX_FMT_NONE)
             enc_ctx->pix_fmt = dec_ctx->sw_pix_fmt;
         else
             enc_ctx->pix_fmt = dec_ctx->pix_fmt;
         enc_ctx->time_base = in_stream->time_base;
-        if (!encoderStream.codec().isEmpty() && dec_ctx->hw_frames_ctx)
+        if (!encoderStream.codec.isEmpty() && dec_ctx->hw_frames_ctx)
             enc_ctx->hw_frames_ctx = av_buffer_ref(dec_ctx->hw_frames_ctx);
         if (d->ctx->ctx()->oformat->flags & AVFMT_GLOBALHEADER)
             enc_ctx->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;

--- a/src/QtAVPlayer/qavmuxerframes.cpp
+++ b/src/QtAVPlayer/qavmuxerframes.cpp
@@ -67,6 +67,26 @@ void QAVMuxerFramesPrivate::doWork()
     }
 }
 
+QAVMuxerFrames::EncoderStream::EncoderStream(const QAVStream &stream)
+    : m_stream(stream)
+{
+}
+
+const QAVStream &QAVMuxerFrames::EncoderStream::stream() const
+{
+    return m_stream;
+}
+
+void QAVMuxerFrames::EncoderStream::setSize(const QSize &size)
+{
+    m_size = size;
+}
+
+const QSize &QAVMuxerFrames::EncoderStream::size() const
+{
+    return m_size;
+}
+
 QAVMuxerFrames::QAVMuxerFrames()
     : QAVMuxer(*new QAVMuxerFramesPrivate(this))
 {
@@ -112,6 +132,42 @@ size_t QAVMuxerFrames::size() const
     return d->frames.size();
 }
 
+int QAVMuxerFrames::load(const QList<QAVStream> &streams, const QString &filename)
+{
+    return load(QList<EncoderStream>(streams.begin(), streams.end()), filename);
+}
+
+int QAVMuxerFrames::load(const QList<EncoderStream> &streams, const QString &filename)
+{
+    Q_D(QAVMuxerFrames);
+    QMutexLocker locker(&d->mutex);
+    reset(locker);
+    int ret = allocFormatContext(filename, locker);
+    if (ret < 0)
+        return ret;
+    ret = initStreams(streams, locker);
+    if (ret < 0)
+        return ret;
+    init(locker);
+    return writeHeader(locker);
+}
+
+int QAVMuxerFrames::initStreams(const QList<EncoderStream> &streams, Locker &locker)
+{
+    Q_D(QAVMuxerFrames);
+    int ret = 0;
+    for (int i = 0; i < streams.size(); ++i) {
+        auto &stream = streams[i];
+        ret = newOutputStream(stream.stream(), locker);
+        if (ret < 0)
+            return ret;
+        ret = initStream(stream, i, d->ctx->ctx()->streams[i], locker);
+        if (ret < 0)
+            return ret;
+    }
+    return 0;
+}
+
 void QAVMuxerFrames::init(Locker &)
 {
     Q_D(QAVMuxerFrames);
@@ -121,9 +177,10 @@ void QAVMuxerFrames::init(Locker &)
     d->workerThread->start();
 }
 
-int QAVMuxerFrames::initStream(const QAVStream &stream, int index, AVStream *out_stream, Locker &)
+int QAVMuxerFrames::initStream(const EncoderStream &encoderStream, int index, AVStream *out_stream, Locker &)
 {
     Q_D(QAVMuxerFrames);
+    const auto &stream = encoderStream.stream();
     auto in_stream = stream.stream();
     auto dec_ctx = stream.codec()->avctx();
     const AVCodec *encoder = nullptr;
@@ -155,8 +212,13 @@ int QAVMuxerFrames::initStream(const QAVStream &stream, int index, AVStream *out
     case AVMEDIA_TYPE_VIDEO:
         codec.reset(new QAVVideoCodec(encoder));
         enc_ctx = codec->avctx();
-        enc_ctx->height = dec_ctx->height;
-        enc_ctx->width = dec_ctx->width;
+        if (!encoderStream.size().isEmpty()) {
+            enc_ctx->height = encoderStream.size().height();
+            enc_ctx->width = encoderStream.size().width();
+        } else {
+            enc_ctx->height = dec_ctx->height;
+            enc_ctx->width = dec_ctx->width;
+        }
         enc_ctx->sample_aspect_ratio = dec_ctx->sample_aspect_ratio;
         // pix_fmt might be not supported by the encoder, f.e. vdpau
         // so falling back to software pixel format

--- a/src/QtAVPlayer/qavmuxerframes.cpp
+++ b/src/QtAVPlayer/qavmuxerframes.cpp
@@ -34,7 +34,6 @@ public:
     {
     }
 
-    QString outputVideoCodec;
     QMap<int, QAVStream> encStreams;
     std::unique_ptr<QThread> workerThread;
     QList<QAVFrame> frames;
@@ -77,6 +76,16 @@ const QAVStream &QAVMuxerFrames::EncoderStream::stream() const
     return m_stream;
 }
 
+void QAVMuxerFrames::EncoderStream::setCodec(const QString &codec)
+{
+    m_codec = codec;
+}
+
+const QString &QAVMuxerFrames::EncoderStream::codec() const
+{
+    return m_codec;
+}
+
 void QAVMuxerFrames::EncoderStream::setSize(const QSize &size)
 {
     m_size = size;
@@ -99,20 +108,6 @@ QAVMuxerFrames::~QAVMuxerFrames()
     flushFrames(locker);
     stop(locker);
     reset(locker);
-}
-
-void QAVMuxerFrames::setOutputVideoCodec(const QString &name)
-{
-    Q_D(QAVMuxerFrames);
-    QMutexLocker locker(&d->mutex);
-    d->outputVideoCodec = name;
-}
-
-QString QAVMuxerFrames::outputVideoCodec() const
-{
-    Q_D(const QAVMuxerFrames);
-    QMutexLocker locker(&d->mutex);
-    return d->outputVideoCodec;
 }
 
 void QAVMuxerFrames::enqueue(const QAVFrame &frame)
@@ -184,19 +179,14 @@ int QAVMuxerFrames::initStream(const EncoderStream &encoderStream, int index, AV
     auto in_stream = stream.stream();
     auto dec_ctx = stream.codec()->avctx();
     const AVCodec *encoder = nullptr;
-    switch (in_stream->codecpar->codec_type) {
-    case AVMEDIA_TYPE_VIDEO:
-        if (!d->outputVideoCodec.isEmpty()) {
-            qDebug() << "Loading: -vcodec" << d->outputVideoCodec;
-            encoder = avcodec_find_encoder_by_name(d->outputVideoCodec.toUtf8().constData());
-            if (!encoder) {
-                qWarning() << "Encoder not found:" << d->outputVideoCodec;
-                return AVERROR(EINVAL);
-            }
-            break;
+    if (!encoderStream.codec().isEmpty()) {
+        qDebug() << "Loading encoder:" << encoderStream.codec();
+        encoder = avcodec_find_encoder_by_name(encoderStream.codec().toUtf8().constData());
+        if (!encoder) {
+            qWarning() << "Encoder not found:" << encoderStream.codec();
+            return AVERROR(EINVAL);
         }
-        [[fallthrough]];
-    default:
+    } else {
         // Transcoding to same codec
         encoder = avcodec_find_encoder(dec_ctx->codec_id);
         if (!encoder) {
@@ -222,12 +212,12 @@ int QAVMuxerFrames::initStream(const EncoderStream &encoderStream, int index, AV
         enc_ctx->sample_aspect_ratio = dec_ctx->sample_aspect_ratio;
         // pix_fmt might be not supported by the encoder, f.e. vdpau
         // so falling back to software pixel format
-        if (d->outputVideoCodec.isEmpty() && dec_ctx->sw_pix_fmt != AV_PIX_FMT_NONE)
+        if (encoderStream.codec().isEmpty() && dec_ctx->sw_pix_fmt != AV_PIX_FMT_NONE)
             enc_ctx->pix_fmt = dec_ctx->sw_pix_fmt;
         else
             enc_ctx->pix_fmt = dec_ctx->pix_fmt;
         enc_ctx->time_base = in_stream->time_base;
-        if (!d->outputVideoCodec.isEmpty() && dec_ctx->hw_frames_ctx)
+        if (!encoderStream.codec().isEmpty() && dec_ctx->hw_frames_ctx)
             enc_ctx->hw_frames_ctx = av_buffer_ref(dec_ctx->hw_frames_ctx);
         if (d->ctx->ctx()->oformat->flags & AVFMT_GLOBALHEADER)
             enc_ctx->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;

--- a/src/QtAVPlayer/qavmuxerframes.h
+++ b/src/QtAVPlayer/qavmuxerframes.h
@@ -24,31 +24,21 @@ public:
      * Defines properties for encoder.
      * Used to initialize AVCodecContext.
      */
-    class EncoderStream
+    struct EncoderStream
     {
-    public:
-        EncoderStream(const QAVStream &stream);
-        const QAVStream &stream() const;
+        EncoderStream(const QAVStream &stream) : stream(stream) {}
+
+        // Underlying stream with codec
+        QAVStream stream;
 
         /**
          * Sets desired output codec. E.g h264_nvenc for h264_cuvid decoder.
          * Uses avcodec_find_encoder_by_name() internally.
          */
-        void setCodec(const QString &name);
+        QString codec;
 
-        // Returns codec name
-        const QString &codec() const;
-
-        // Sets the size of the frames
-        void setSize(const QSize &size);
-
-        // Returns the size of the frames
-        const QSize &size() const;
-
-    private:
-        QAVStream m_stream;
-        QString m_codec;
-        QSize m_size;
+        // Sets the size of the input frames
+        QSize size;
     };
 
     QAVMuxerFrames();

--- a/src/QtAVPlayer/qavmuxerframes.h
+++ b/src/QtAVPlayer/qavmuxerframes.h
@@ -9,18 +9,52 @@
 #define QAVMUXERFRAMES_H
 
 #include <QtAVPlayer/qavmuxer.h>
+#include <QSize>
 
 QT_BEGIN_NAMESPACE
 
 /**
- * Re-encodes the frames using the same encoder
+ * Re-encodes the frames using specific encoder
  */
 class QAVMuxerFramesPrivate;
 class QAVMuxerFrames : public QAVMuxer
 {
 public:
+    /**
+     * Defines properties for encoder.
+     * Used to initialize AVCodecContext.
+     */
+    class EncoderStream
+    {
+    public:
+        EncoderStream(const QAVStream &stream);
+        const QAVStream &stream() const;
+
+        // Sets the size of the frames
+        void setSize(const QSize &size);
+
+        // Returns the size of the frames
+        const QSize &size() const;
+
+    private:
+        QAVStream m_stream;
+        QSize m_size;
+    };
+
     QAVMuxerFrames();
     ~QAVMuxerFrames() override;
+
+    /**
+     * Loads the encoder based on parsed streams, format is negotiated from filename.
+     * It uses AVCodecContext from the stream's codec to initialize the encoder.
+     */
+    int load(const QList<QAVStream> &streams, const QString &filename);
+
+    /**
+     * Loads the encoder based on parsed streams and params from EncoderStream.
+     * If params are not set, the stream's codec AVCodecContext is used instead.
+     */
+    int load(const QList<EncoderStream> &streams, const QString &filename);
 
     /**
      * Sets desired output codec. E.g h264_nvenc for h264_cuvid decoder.
@@ -41,8 +75,9 @@ public:
     int write(const QAVSubtitleFrame &frame);
 
 private:
-    void init(Locker &) override;
-    int initStream(const QAVStream &stream, int index, AVStream *out_stream, Locker &) override;
+    int initStreams(const QList<EncoderStream> &streams, Locker &);
+    void init(Locker &);
+    int initStream(const EncoderStream &stream, int index, AVStream *out_stream, Locker &);
     // Need to make a copy of frame
     // streamIndex is needed to flush empty frame
     int write(QAVFrame frame, int streamIndex, Locker &);

--- a/src/QtAVPlayer/qavmuxerframes.h
+++ b/src/QtAVPlayer/qavmuxerframes.h
@@ -30,6 +30,15 @@ public:
         EncoderStream(const QAVStream &stream);
         const QAVStream &stream() const;
 
+        /**
+         * Sets desired output codec. E.g h264_nvenc for h264_cuvid decoder.
+         * Uses avcodec_find_encoder_by_name() internally.
+         */
+        void setCodec(const QString &name);
+
+        // Returns codec name
+        const QString &codec() const;
+
         // Sets the size of the frames
         void setSize(const QSize &size);
 
@@ -38,6 +47,7 @@ public:
 
     private:
         QAVStream m_stream;
+        QString m_codec;
         QSize m_size;
     };
 
@@ -55,14 +65,6 @@ public:
      * If params are not set, the stream's codec AVCodecContext is used instead.
      */
     int load(const QList<EncoderStream> &streams, const QString &filename);
-
-    /**
-     * Sets desired output codec. E.g h264_nvenc for h264_cuvid decoder.
-     * Uses avcodec_find_encoder_by_name() internally.
-     * Should be called before load().
-     */
-    void setOutputVideoCodec(const QString &name);
-    QString outputVideoCodec() const;
 
     // Adds the frame to the queue
     void enqueue(const QAVFrame &frame);

--- a/src/QtAVPlayer/qavmuxerpackets.cpp
+++ b/src/QtAVPlayer/qavmuxerpackets.cpp
@@ -21,8 +21,34 @@ QAVMuxerPackets::~QAVMuxerPackets()
     unload();
 }
 
-void QAVMuxerPackets::init(Locker &)
+int QAVMuxerPackets::load(const QList<QAVStream> &streams, const QString &filename)
 {
+    Q_D(QAVMuxer);
+    QMutexLocker locker(&d->mutex);
+    reset(locker);
+    int ret = allocFormatContext(filename, locker);
+    if (ret < 0)
+        return ret;
+    ret = initStreams(streams, locker);
+    if (ret < 0)
+        return ret;
+    return writeHeader(locker);
+}
+
+int QAVMuxerPackets::initStreams(const QList<QAVStream> &streams, Locker &locker)
+{
+    Q_D(QAVMuxer);
+    int ret = 0;
+    for (int i = 0; i < streams.size(); ++i) {
+        auto &stream = streams[i];
+        ret = newOutputStream(stream, locker);
+        if (ret < 0)
+            return ret;
+        ret = initStream(stream, i, d->ctx->ctx()->streams[i], locker);
+        if (ret < 0)
+            return ret;
+    }
+    return 0;
 }
 
 int QAVMuxerPackets::initStream(const QAVStream &stream, int, AVStream *out_stream, Locker &)
@@ -42,7 +68,7 @@ int QAVMuxerPackets::write(const QAVPacket &packet)
     Q_D(QAVMuxer);
     QMutexLocker locker(&d->mutex);
     if (!d->loaded || !packet.stream())
-        return 0;
+        return AVERROR(EINVAL);
     int index = d->outputStreamIndex(packet.stream(), locker);
     if (index < 0)
         return AVERROR(EINVAL);

--- a/src/QtAVPlayer/qavmuxerpackets.h
+++ b/src/QtAVPlayer/qavmuxerpackets.h
@@ -24,12 +24,15 @@ public:
     QAVMuxerPackets() = default;
     ~QAVMuxerPackets() override;
 
+    // Loads the encoder based on parsed streams, format is negotiated from filename
+    int load(const QList<QAVStream> &streams, const QString &filename);
+
     // Writes the packet directly to the encoder
     int write(const QAVPacket &packet);
 
 private:
-    void init(Locker &) override;
-    int initStream(const QAVStream &stream, int index, AVStream *out_stream, Locker &) override;
+    int initStreams(const QList<QAVStream> &streams, Locker &);
+    int initStream(const QAVStream &stream, int index, AVStream *out_stream, Locker &);
     int flushFrames(Locker &) override;
     // Need to make a copy of packet
     int write(QAVPacket packet, int streamIndex, Locker &);

--- a/tests/auto/integration/qavdemuxer/tst_qavdemuxer.cpp
+++ b/tests/auto/integration/qavdemuxer/tst_qavdemuxer.cpp
@@ -60,7 +60,7 @@ private slots:
     void muxerEnqueueFramesFromDev();
     void muxerWritePacketsFromMultiSources();
     void muxerWritePacketsFromDev();
-    void muxerFramesCodecInfo();
+    void muxerFramesEncoderStreams();
     void muxerFramesScaleHW();
 };
 
@@ -851,7 +851,7 @@ void tst_QAVDemuxer::muxerWritePacketsFromDev()
     // ffmpeg -f rawvideo -pix_fmt yuyv422 -s:v 640x480 -r 25 -i output.yuv -c:v libx264 output.mp4
 }
 
-void tst_QAVDemuxer::muxerFramesCodecInfo()
+void tst_QAVDemuxer::muxerFramesEncoderStreams()
 {
     QFileInfo file(testData("colors.mp4"));
     QAVDemuxer d;
@@ -860,23 +860,23 @@ void tst_QAVDemuxer::muxerFramesCodecInfo()
     QVERIFY(d.load(file.absoluteFilePath()) >= 0);
     QVERIFY(!d.availableVideoStreams().isEmpty());
     QSize size(128, 96);
+    QList<QAVMuxerFrames::EncoderStream> encoderStreams;
     for (auto &s : d.availableVideoStreams()) {
         QVERIFY(s.codec());
         QCOMPARE(s.codec()->size(), QSize(160, 120));
-        s.codec()->avctx()->width = size.width();
-        s.codec()->avctx()->height = size.height();
-        QVERIFY(s.codec()->size() == size);
-    }
-    for (auto &s : d.availableVideoStreams()) {
-        QCOMPARE(s.codec()->size(), size);
+        QAVMuxerFrames::EncoderStream stream(s);
+        stream.setSize(size);
+        QCOMPARE(stream.size(), size);
+        encoderStreams.push_back(stream);
     }
     for (auto &s : d.availableAudioStreams()) {
         QVERIFY(s.codec());
         QVERIFY(s.codec()->size().isEmpty());
+        encoderStreams.push_back(s);
     }
 
     QAVMuxerFrames m;
-    QVERIFY(m.load(d.availableStreams(), "colors.mkv") >= 0);
+    QVERIFY(m.load(encoderStreams, "colors.mkv") >= 0);
 
     QAVPacket p;
     while (d.read(p) >= 0) {
@@ -914,24 +914,27 @@ void tst_QAVDemuxer::muxerFramesScaleHW()
     QCOMPARE(codec->avctx()->pix_fmt, AV_PIX_FMT_CUDA);
     QVERIFY(!d.availableVideoStreams().isEmpty());
     QSize size(128, 96);
+    QList<QAVMuxerFrames::EncoderStream> encoderStreams;
     for (auto &s : d.availableVideoStreams()) {
         QVERIFY(s.codec());
         QCOMPARE(s.codec()->size(), QSize(560, 320));
         // It does not rescale, sets output size only
-        s.codec()->avctx()->width = size.width();
-        s.codec()->avctx()->height = size.height();
-        QVERIFY(s.codec()->size() == size);
+        QAVMuxerFrames::EncoderStream stream(s);
+        stream.setSize(size);
+        encoderStreams.push_back(stream);
     }
+    for (auto &s : d.availableAudioStreams())
+        encoderStreams.push_back(s);
 
     QAVMuxerFrames m;
     // Using software codec
-    QVERIFY(m.load(d.availableStreams(), "small.mkv") >= 0);
+    QVERIFY(m.load(encoderStreams, "small.mkv") >= 0);
     m.setOutputVideoCodec("notfound");
-    QVERIFY(m.load(d.availableStreams(), "small.mkv") < 0);
+    QVERIFY(m.load(encoderStreams, "small.mkv") < 0);
 
     m.setOutputVideoCodec("h264_nvenc");
     QCOMPARE(m.outputVideoCodec(), "h264_nvenc");
-    QVERIFY(m.load(d.availableStreams(), "small.mkv") >= 0);
+    QVERIFY(m.load(encoderStreams, "small.mkv") >= 0);
 
     QAVPacket p;
     while (d.read(p) >= 0) {

--- a/tests/auto/integration/qavdemuxer/tst_qavdemuxer.cpp
+++ b/tests/auto/integration/qavdemuxer/tst_qavdemuxer.cpp
@@ -865,8 +865,7 @@ void tst_QAVDemuxer::muxerFramesEncoderStreams()
         QVERIFY(s.codec());
         QCOMPARE(s.codec()->size(), QSize(160, 120));
         QAVMuxerFrames::EncoderStream stream(s);
-        stream.setSize(size);
-        QCOMPARE(stream.size(), size);
+        stream.size = size;
         encoderStreams.push_back(stream);
     }
     for (auto &s : d.availableAudioStreams()) {
@@ -920,7 +919,7 @@ void tst_QAVDemuxer::muxerFramesScaleHW()
         QCOMPARE(s.codec()->size(), QSize(560, 320));
         // It does not rescale, sets output size only
         QAVMuxerFrames::EncoderStream stream(s);
-        stream.setSize(size);
+        stream.size = size;
         encoderStreams.push_back(stream);
     }
     for (auto &s : d.availableAudioStreams())
@@ -930,10 +929,10 @@ void tst_QAVDemuxer::muxerFramesScaleHW()
     // Using software codec
     QVERIFY(m.load(encoderStreams, "small.mkv") >= 0);
 
-    encoderStreams[0].setCodec("notfound");
+    encoderStreams[0].codec = "notfound";
     QVERIFY(m.load(encoderStreams, "small.mkv") < 0);
 
-    encoderStreams[0].setCodec("h264_nvenc");
+    encoderStreams[0].codec = "h264_nvenc";
     QVERIFY(m.load(encoderStreams, "small.mkv") >= 0);
 
     QAVPacket p;

--- a/tests/auto/integration/qavdemuxer/tst_qavdemuxer.cpp
+++ b/tests/auto/integration/qavdemuxer/tst_qavdemuxer.cpp
@@ -929,11 +929,11 @@ void tst_QAVDemuxer::muxerFramesScaleHW()
     QAVMuxerFrames m;
     // Using software codec
     QVERIFY(m.load(encoderStreams, "small.mkv") >= 0);
-    m.setOutputVideoCodec("notfound");
+
+    encoderStreams[0].setCodec("notfound");
     QVERIFY(m.load(encoderStreams, "small.mkv") < 0);
 
-    m.setOutputVideoCodec("h264_nvenc");
-    QCOMPARE(m.outputVideoCodec(), "h264_nvenc");
+    encoderStreams[0].setCodec("h264_nvenc");
     QVERIFY(m.load(encoderStreams, "small.mkv") >= 0);
 
     QAVPacket p;

--- a/tests/auto/integration/qavplayer/tst_qavplayer.cpp
+++ b/tests/auto/integration/qavplayer/tst_qavplayer.cpp
@@ -3635,11 +3635,12 @@ void tst_QAVPlayer::muxerScaleHW()
     QAVPlayer p;
     p.setSynced(false);
     QSize size;
+    QString codec;
 #if defined(QT_AVPLAYER_CUDA)
     p.setInputVideoCodec("h264_cuvid");
     p.setFilter("scale_cuda=160:120");
     size = {160, 120};
-    m.setOutputVideoCodec("h264_nvenc");
+    codec = "h264_nvenc";
 #endif
     if (size.isEmpty())
         return;
@@ -3662,7 +3663,8 @@ void tst_QAVPlayer::muxerScaleHW()
     QList<QAVMuxerFrames::EncoderStream> encoderStreams;
     for (auto &s : videoStreams) {
         QAVMuxerFrames::EncoderStream stream(s);
-        stream.setSize(size);
+        stream.size = size;
+        stream.codec = codec;
         encoderStreams.push_back(stream);
     }
     for (auto &s : p.availableAudioStreams())

--- a/tests/auto/integration/qavplayer/tst_qavplayer.cpp
+++ b/tests/auto/integration/qavplayer/tst_qavplayer.cpp
@@ -3637,8 +3637,8 @@ void tst_QAVPlayer::muxerScaleHW()
     QSize size;
 #if defined(QT_AVPLAYER_CUDA)
     p.setInputVideoCodec("h264_cuvid");
-    p.setFilter("scale_cuda=1920:1080");
-    size = {1920, 1080};
+    p.setFilter("scale_cuda=160:120");
+    size = {160, 120};
     m.setOutputVideoCodec("h264_nvenc");
 #endif
     if (size.isEmpty())
@@ -3659,9 +3659,15 @@ void tst_QAVPlayer::muxerScaleHW()
     auto c = videoStreams[0].codec();
     QVERIFY(c);
     QCOMPARE(c->size(), QSize(560, 320));
-    c->avctx()->width = size.width();
-    c->avctx()->height = size.height();
-    QVERIFY(m.load(p.availableStreams(), "output.mkv") >= 0);
+    QList<QAVMuxerFrames::EncoderStream> encoderStreams;
+    for (auto &s : videoStreams) {
+        QAVMuxerFrames::EncoderStream stream(s);
+        stream.setSize(size);
+        encoderStreams.push_back(stream);
+    }
+    for (auto &s : p.availableAudioStreams())
+        encoderStreams.push_back(s);
+    QVERIFY(m.load(encoderStreams, "output.mkv") >= 0);
 
     p.play();
     QTRY_VERIFY(p.mediaStatus() == QAVPlayer::EndOfMedia);


### PR DESCRIPTION
Some params should be known in advance, before opening the codecs. E.g. frames size, pixel format, codec id etc.
For now loading the muxer is done before starting the demuxing, and no frames available.
Previously all these params were grabbed from codecs `AVCodecContext` per stream and it was ok until frames are not changed via filters.

In case if the filter is applied, it could change the size of frame, format etc. So it requires to pass these params to encoder. Or to use decoded frames before opening the encoder.

But since it complicates loading of the muxer, decided to add `EncoderStream` which allows to pass params to initialize AVCodecContext before frames are available.

