### PR TITLE
fix: m_rhi missing due to an incorrect conditional

### DIFF
--- a/src/QtAVPlayer/qavvideoframe.cpp
+++ b/src/QtAVPlayer/qavvideoframe.cpp
@@ -421,7 +421,7 @@ private:
     QVideoFrameFormat m_videoFormat;
     QVideoFrame::MapMode m_mode = QVideoFrame::NotMapped;
     QVariant m_textures;
-#if QT_VERSION < QT_VERSION_CHECK(6, 4, 0)
+#if QT_VERSION >= QT_VERSION_CHECK(6, 4, 0)
     QRhi *m_rhi = nullptr;
 #endif
 };


### PR DESCRIPTION
The error appeared when using Qt 6.11.1-1 on Arch Linux