### PR TITLE
Fix position slider jumping on click

### DIFF
--- a/examples/qml_player/playercontroller.cpp
+++ b/examples/qml_player/playercontroller.cpp
@@ -145,8 +145,6 @@ void PlayerController::connectPlayerSignals()
     });
 
     QObject::connect(&m_player, &QAVPlayer::seeked, this, [this](qint64 pos) {
-        m_position = pos;
-        emit positionChanged();
         m_audioOutput.setVolume(m_volume);
         m_posTimer.start();
     });
@@ -254,6 +252,8 @@ void PlayerController::seek(qint64 ms)
 {
     if (ms == m_position)
         return;
+    m_position = ms;
+    emit positionChanged();
     m_posTimer.stop();
     m_audioOutput.setVolume(0);
     m_audioOutput.clearQueue();


### PR DESCRIPTION
The position slider was jumping back to the previous position then to the new position because position updates were deferred until the seek completed.

Since seek() is asynchronous, when the slider was released the binding would re-enable and read the old m_position value, causing the slider to jump back.

Fix: Update m_position and emit positionChanged() immediately in seek() so the binding has the correct new value when it re-enables after mouse release. The actual seek operation still completes asynchronously without issues.