### PR TITLE
Introduce QAVPlayer::maxQueuedBytes()

### DIFF
--- a/src/QtAVPlayer/qavplayer.cpp
+++ b/src/QtAVPlayer/qavplayer.cpp
@@ -1,5 +1,5 @@
 /***************************************************************
- * Copyright (C) 2020, 2025, Val Doroshchuk <valbok@gmail.com> *
+ * Copyright (C) 2020, 2026, Val Doroshchuk <valbok@gmail.com> *
  *                                                             *
  * This file is part of QtAVPlayer.                            *
  * Free Qt Media Player based on FFmpeg.                       *
@@ -158,6 +158,7 @@ public:
     QWaitCondition waitCond;
     bool eof = false;
     std::atomic_bool startDemuxing{false};
+    std::atomic<int> maxQueuedBytes{15 * 1024 * 1024};
 
     QList<QString> filterDescs;
     QAVFilters filters;
@@ -595,12 +596,11 @@ void QAVPlayerPrivate::doLoad()
 
 void QAVPlayerPrivate::doDemux()
 {
-    const int maxQueueBytes = 15 * 1024 * 1024;
     QMutex waiterMutex;
     QWaitCondition waiter;
 
     while (!quit) {
-        if (videoQueue.bytes() + audioQueue.bytes() > maxQueueBytes
+        if (videoQueue.bytes() + audioQueue.bytes() > maxQueuedBytes
             || (videoQueue.enough() && audioQueue.enough())
             || !startDemuxing)
         {
@@ -1458,6 +1458,16 @@ void QAVPlayer::setLogsLevelBackend(int level)
 QAVStream::Progress QAVPlayer::progress(const QAVStream &s) const
 {
     return d_func()->demuxer.progress(s);
+}
+
+void QAVPlayer::setMaxQueuedBytes(int size)
+{
+    d_func()->maxQueuedBytes = size;
+}
+
+int QAVPlayer::maxQueuedBytes() const
+{
+    return d_func()->maxQueuedBytes;
 }
 
 #ifndef QT_NO_DEBUG_STREAM

--- a/src/QtAVPlayer/qavplayer.h
+++ b/src/QtAVPlayer/qavplayer.h
@@ -1,5 +1,5 @@
 /***************************************************************
- * Copyright (C) 2020, 2025, Val Doroshchuk <valbok@gmail.com> *
+ * Copyright (C) 2020, 2026, Val Doroshchuk <valbok@gmail.com> *
  *                                                             *
  * This file is part of QtAVPlayer.                            *
  * Free Qt Media Player based on FFmpeg.                       *
@@ -126,6 +126,19 @@ public:
     void setVideoCodecOptions(const QMap<QString, QString> &opts);
 
     QAVStream::Progress progress(const QAVStream &stream) const;
+
+    /**
+     * Returns the maximum number of bytes that can be buffered in the
+     * audio and video queues.
+     *
+     * If the combined size of the queues exceeds this limit, the demuxer
+     * thread pauses until the decoding threads consume enough packets,
+     * after which demuxing resumes.
+     *
+     * Default value is 15Mb.
+     */
+    int maxQueuedBytes() const;
+    void setMaxQueuedBytes(int size);
 
 public Q_SLOTS:
     void play();

--- a/tests/auto/integration/qavplayer/tst_qavplayer.cpp
+++ b/tests/auto/integration/qavplayer/tst_qavplayer.cpp
@@ -511,6 +511,8 @@ void tst_QAVPlayer::playVideo()
     QCOMPARE(spyVideoFrameRateChanged.count(), 1);
 
     QTRY_VERIFY(p.position() != 0);
+    p.setMaxQueuedBytes(1000 * 1024 * 1024);
+    QCOMPARE(p.maxQueuedBytes(), 1000 * 1024 * 1024);
 }
 
 void tst_QAVPlayer::pauseVideo()
@@ -3499,7 +3501,7 @@ void tst_QAVPlayer::outputFile()
     p.setOutput("output");
     p.play();
     QTRY_COMPARE(p.mediaStatus(), QAVPlayer::InvalidMedia);
-    QCOMPARE(err, QAVPlayer::MuxerError);
+    QTRY_COMPARE(err, QAVPlayer::MuxerError);
 
     // Set before the source
     p.setOutput({});


### PR DESCRIPTION
If decoding threads are too slow to consume demuxed packets. The demuxer thread will wait until the packets from queues are hanlded to continue the demuxing to prevent allocating more memory.