### PR TITLE
Wait for more frames in QAVAudioOutputDevice::readData also for Linux

### DIFF
--- a/src/QtAVPlayer/qavaudiooutputdevice.cpp
+++ b/src/QtAVPlayer/qavaudiooutputdevice.cpp
@@ -47,9 +47,7 @@ qint64 QAVAudioOutputDevice::readData(char *data, qint64 len)
     qint64 bytesWritten = 0;
     while (len && !d->quit) {
         if (d->frames.isEmpty()) {
-#if defined(Q_OS_WIN)
             d->cond.wait(&d->mutex);
-#endif
             if (d->quit || d->flush || d->frames.isEmpty()) {
                 d->flush = true;
                 break;


### PR DESCRIPTION
If there is not enough frames enqueued to `QAVAudioOutputDevice`, now it should wait for more. And not producing the silence.
This should suppress audio stuttering after seek.
But it could be still an issue when device is waiting to fill the buffer on time.
Closes #598