### PR TITLE
Introduce max queued bytes and seconds to limit the demuxed packets

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ player->setSource(file);
 Notes:
 - Set the `QT_AVPLAYER_NO_HWDEVICE` environment variable to force software decoding.
 - You can also call `player.setInputVideoCodec("software")` to force software decoding for a specific player.
+- Set the `QT_AVPLAYER_MAX_QUEUED_BYTES` or `QT_AVPLAYER_MAX_QUEUED_SEC` environment variables to limit the amount of data buffered in the audio and video queues while demuxing. Once the configured limit is reached, demuxing pauses until packets are consumed by the decoder.
 - Not every FFmpeg decoder/filter supports hardware acceleration — QtAVPlayer falls back to software decoding automatically when needed.
 
 

--- a/src/QtAVPlayer/qavpacketqueue_p.h
+++ b/src/QtAVPlayer/qavpacketqueue_p.h
@@ -1,9 +1,9 @@
-/*********************************************************
- * Copyright (C) 2020, Val Doroshchuk <valbok@gmail.com> *
- *                                                       *
- * This file is part of QtAVPlayer.                      *
- * Free Qt Media Player based on FFmpeg.                 *
- *********************************************************/
+/***************************************************************
+ * Copyright (C) 2020, 2026, Val Doroshchuk <valbok@gmail.com> *
+ *                                                             *
+ * This file is part of QtAVPlayer.                            *
+ * Free Qt Media Player based on FFmpeg.                       *
+ ***************************************************************/
 
 #ifndef QAVPACKETQUEUE_H
 #define QAVPACKETQUEUE_H
@@ -190,11 +190,16 @@ public:
         m_producerWaiter.wakeAll();
     }
 
-    bool enough() const
+    int size() const
     {
         QMutexLocker locker(&m_mutex);
-        const int minFrames = 15;
-        return m_packets.size() > minFrames && (!m_duration || m_duration > 1.0);
+        return m_packets.size();
+    }
+
+    double duration() const
+    {
+        QMutexLocker locker(&m_mutex);
+        return m_duration;
     }
 
     int bytes() const
@@ -263,7 +268,7 @@ private:
     bool m_wake = false;
 
     int m_bytes = 0;
-    int m_duration = 0;
+    double m_duration = 0;
 
 private:
     Q_DISABLE_COPY(QAVPacketQueue)

--- a/src/QtAVPlayer/qavplayer.cpp
+++ b/src/QtAVPlayer/qavplayer.cpp
@@ -1,5 +1,5 @@
 /***************************************************************
- * Copyright (C) 2020, 2025, Val Doroshchuk <valbok@gmail.com> *
+ * Copyright (C) 2020, 2026, Val Doroshchuk <valbok@gmail.com> *
  *                                                             *
  * This file is part of QtAVPlayer.                            *
  * Free Qt Media Player based on FFmpeg.                       *
@@ -595,13 +595,17 @@ void QAVPlayerPrivate::doLoad()
 
 void QAVPlayerPrivate::doDemux()
 {
-    const int maxBytes = 15 * 1024 * 1024;
+    const auto bytesEnv = qgetenv("QT_AVPLAYER_MAX_QUEUED_BYTES");
+    const auto maxBytes = !bytesEnv.isEmpty() ? bytesEnv.toInt() : 15728640;
+    const auto secEnv = qgetenv("QT_AVPLAYER_MAX_QUEUED_SEC");
+    const auto maxSec = !secEnv.isEmpty() ? secEnv.toDouble() : 1.0;
+
     QMutex waiterMutex;
     QWaitCondition waiter;
 
     while (!quit) {
         if (videoQueue.bytes() + audioQueue.bytes() + subtitleQueue.bytes() > maxBytes
-            || (videoQueue.enough() && audioQueue.enough())
+            || (videoQueue.duration() > maxSec && audioQueue.duration() > maxSec)
             || !startDemuxing)
         {
             QMutexLocker locker(&waiterMutex);

--- a/src/QtAVPlayer/qavplayer.h
+++ b/src/QtAVPlayer/qavplayer.h
@@ -1,5 +1,5 @@
 /***************************************************************
- * Copyright (C) 2020, 2025, Val Doroshchuk <valbok@gmail.com> *
+ * Copyright (C) 2020, 2026, Val Doroshchuk <valbok@gmail.com> *
  *                                                             *
  * This file is part of QtAVPlayer.                            *
  * Free Qt Media Player based on FFmpeg.                       *


### PR DESCRIPTION
Adding  `QT_AVPLAYER_MAX_QUEUED_BYTES` and `QT_AVPLAYER_MAX_QUEUED_SEC` environment variables to limit the amount of data buffered in the audio and video queues while demuxing. Once the configured limit reached, demuxing pauses until packets are consumed by the decoder.

Setting high value will increase buffered size, but could potentially help in more smooth rendering, since the decoder threads would deliver frames _more_ precisely.

Adding env variables in favor of config param per player.