### PR TITLE
Introduce scaling in QAVMuxerFrames

### DIFF
--- a/src/QtAVPlayer/qavmuxerframes.cpp
+++ b/src/QtAVPlayer/qavmuxerframes.cpp
@@ -316,7 +316,7 @@ int QAVMuxerFrames::writeFilters(const QAVFrame &frame, int index, Locker &locke
         if (ret < 0 && ret != AVERROR(EAGAIN)) {
             // Try filters again
             filteredFrames.clear();
-            if (ret != AVERROR(ENOTSUP))
+            if (ret != AVERROR(ENOTSUP) || !frame)
                 return ret;
             ret = applyFilters(frame, index, locker);
             if (ret < 0)
@@ -362,7 +362,7 @@ int QAVMuxerFrames::writeFrame(const QAVFrame &frame, int index, Locker &locker)
     auto &encStream = d->encStreams[index];
     auto enc_ctx = encStream.codec()->avctx();
     // Check if the size is the same as encoder
-    if (enc_ctx->codec_type == AVMEDIA_TYPE_VIDEO) {
+    if (frame && enc_ctx->codec_type == AVMEDIA_TYPE_VIDEO) {
         QSize frameSize(frame.frame()->width, frame.frame()->height);
         QSize encSize(enc_ctx->width, enc_ctx->height);
         // If the size of the frame differs to the encoder's
@@ -494,6 +494,7 @@ void QAVMuxerFrames::reset(Locker &locker)
     Q_D(QAVMuxerFrames);
     stop(locker);
     d->encStreams.clear();
+    d->filterDescs.clear();
     d->filters.clear();
     QAVMuxer::reset(locker);
 }

--- a/src/QtAVPlayer/qavmuxerframes.cpp
+++ b/src/QtAVPlayer/qavmuxerframes.cpp
@@ -492,6 +492,7 @@ void QAVMuxerFrames::reset(Locker &locker)
     Q_D(QAVMuxerFrames);
     stop(locker);
     d->encStreams.clear();
+    d->filters.clear();
     QAVMuxer::reset(locker);
 }
 

--- a/src/QtAVPlayer/qavmuxerframes.cpp
+++ b/src/QtAVPlayer/qavmuxerframes.cpp
@@ -373,7 +373,8 @@ int QAVMuxerFrames::writeFrame(const QAVFrame &frame, int index, Locker &locker)
                 d->filterDescs[index] = filter;
                 int ret = applyFilters(frame, index, locker);
                 if (ret < 0) {
-                    d->filterDescs.clear();
+                    d->filterDescs.remove(index);
+                    d->filters.remove(index);
                     return ret;
                 }
             }

--- a/src/QtAVPlayer/qavmuxerframes.cpp
+++ b/src/QtAVPlayer/qavmuxerframes.cpp
@@ -307,8 +307,8 @@ int QAVMuxerFrames::writeFilters(const QAVFrame &frame, int index, Locker &locke
     auto enc_ctx = encStream.codec()->avctx();
     int ret = 0;
     // Try to re-apply filters on error
-    int i = 2;
-    while (i-- > 0) {
+    bool retry = false;
+    do {
         if (frame)
             ret = d->filters[index]->write(enc_ctx->codec_type, frame);
         if (ret >= 0 || ret == AVERROR(EAGAIN))
@@ -316,14 +316,15 @@ int QAVMuxerFrames::writeFilters(const QAVFrame &frame, int index, Locker &locke
         if (ret < 0 && ret != AVERROR(EAGAIN)) {
             // Try filters again
             filteredFrames.clear();
-            if (ret != AVERROR(ENOTSUP) || !frame || i == 1)
+            if (ret != AVERROR(ENOTSUP) || !frame || retry)
                 return ret;
             ret = applyFilters(frame, index, locker);
-            if (ret < 0)
+            if (ret < 0) {
+                retry = true;
                 continue;
+            }
         }
-        break;
-    }
+    } while (retry);
     if (ret < 0)
         return ret;
     while (!filteredFrames.isEmpty()) {

--- a/src/QtAVPlayer/qavmuxerframes.cpp
+++ b/src/QtAVPlayer/qavmuxerframes.cpp
@@ -40,8 +40,8 @@ public:
     QList<QAVFrame> frames;
     QWaitCondition cond;
     bool quit = false;
-    QString filterDesc;
-    QAVFilters filters;
+    QMap<int, QString> filterDescs;
+    QMap<int, QSharedPointer<QAVFilters>> filters;
 
     void doWork();
 };
@@ -273,7 +273,7 @@ int QAVMuxerFrames::initStream(const EncoderStream &encoderStream, int index, AV
     return 0;
 }
 
-int QAVMuxerFrames::applyFilters(const QAVFrame &frame, Locker &)
+int QAVMuxerFrames::applyFilters(const QAVFrame &frame, int index, Locker &)
 {
     Q_D(QAVMuxerFrames);
     QAVStream videoStream;
@@ -287,8 +287,9 @@ int QAVMuxerFrames::applyFilters(const QAVFrame &frame, Locker &)
         qWarning() << "Unsupported codec type:" << frame.stream().stream()->codecpar->codec_type;
         return AVERROR(ENOTSUP);
     }
-    int ret = d->filters.createFilters(
-        {d->filterDesc},
+    d->filters[index].reset(new QAVFilters);
+    int ret = d->filters[index]->createFilters(
+        {d->filterDescs[index]},
         frame,
         videoStream,
         audioStream);
@@ -298,25 +299,33 @@ int QAVMuxerFrames::applyFilters(const QAVFrame &frame, Locker &)
 int QAVMuxerFrames::writeFilters(const QAVFrame &frame, int index, Locker &locker)
 {
     Q_D(QAVMuxerFrames);
+    // No filters available
+    if (!d->filters.contains(index))
+        return write(frame, index, locker);
     QList<QAVFrame> filteredFrames;
-    auto stream = frame.stream().stream();
+    auto &encStream = d->encStreams[index];
+    auto enc_ctx = encStream.codec()->avctx();
     int ret = 0;
-    if (frame) {
-        ret = d->filters.write(stream->codecpar->codec_type, frame);
+    // Try to re-apply filters on error
+    int i = 2;
+    while (i-- > 0) {
+        if (frame)
+            ret = d->filters[index]->write(enc_ctx->codec_type, frame);
         if (ret >= 0 || ret == AVERROR(EAGAIN))
-            ret = d->filters.read(stream->codecpar->codec_type, frame, filteredFrames);
+            ret = d->filters[index]->read(enc_ctx->codec_type, frame, filteredFrames);
         if (ret < 0 && ret != AVERROR(EAGAIN)) {
             // Try filters again
             filteredFrames.clear();
             if (ret != AVERROR(ENOTSUP))
                 return ret;
-            ret = applyFilters(frame, locker);
+            ret = applyFilters(frame, index, locker);
             if (ret < 0)
-                return ret;
+                continue;
         }
-    } else {
-        filteredFrames.push_back(frame);
+        break;
     }
+    if (ret < 0)
+        return ret;
     while (!filteredFrames.isEmpty()) {
         auto &filteredFrame = filteredFrames.front();
         ret = write(filteredFrame, index, locker);
@@ -358,18 +367,17 @@ int QAVMuxerFrames::writeFrame(const QAVFrame &frame, int index, Locker &locker)
         QSize encSize(enc_ctx->width, enc_ctx->height);
         // If the size of the frame differs to the encoder's
         // then need to implicitly resize the frame using a filter.
-        if (frameSize != encSize) {
-            if (d->filterDesc.isEmpty()) {
+        if (!frameSize.isNull() && frameSize != encSize) {
+            if (!d->filterDescs.contains(index)) {
                 auto filter = scaleFilter(AVPixelFormat(frame.frame()->format), encSize);
-                d->filterDesc = filter;
-                int ret = applyFilters(frame, locker);
+                d->filterDescs[index] = filter;
+                int ret = applyFilters(frame, index, locker);
                 if (ret < 0)
                     return ret;
             }
-            return writeFilters(frame, index, locker);
         }
     }
-    return write(frame, index, locker);
+    return writeFilters(frame, index, locker);
 }
 
 int QAVMuxerFrames::write(const QAVFrame &frame)
@@ -490,12 +498,14 @@ void QAVMuxerFrames::reset(Locker &locker)
 int QAVMuxerFrames::flushFrames(Locker &locker)
 {
     Q_D(QAVMuxerFrames);
+    for (auto &f : d->filters)
+        f->flush();
     for (auto &s : d->encStreams) {
         // no flushing for subtitles
         bool isSub = s.codec()->avctx()->codec_type == AVMEDIA_TYPE_SUBTITLE;
         if (isSub)
             continue;
-        int ret = write(QAVFrame(), s.index(), locker);
+        int ret = writeFrame(QAVFrame(), s.index(), locker);
         if (ret < 0 && ret != AVERROR_EOF) {
             qWarning() << d->filename << ": Could not flush:" << QAVMuxerPrivate::err2str(ret);
             return ret;

--- a/src/QtAVPlayer/qavmuxerframes.cpp
+++ b/src/QtAVPlayer/qavmuxerframes.cpp
@@ -316,7 +316,7 @@ int QAVMuxerFrames::writeFilters(const QAVFrame &frame, int index, Locker &locke
         if (ret < 0 && ret != AVERROR(EAGAIN)) {
             // Try filters again
             filteredFrames.clear();
-            if (ret != AVERROR(ENOTSUP) || !frame)
+            if (ret != AVERROR(ENOTSUP) || !frame || i == 1)
                 return ret;
             ret = applyFilters(frame, index, locker);
             if (ret < 0)

--- a/src/QtAVPlayer/qavmuxerframes.cpp
+++ b/src/QtAVPlayer/qavmuxerframes.cpp
@@ -293,6 +293,10 @@ int QAVMuxerFrames::applyFilters(const QAVFrame &frame, int index, Locker &)
         frame,
         videoStream,
         audioStream);
+    if (ret < 0) {
+        d->filterDescs.remove(index);
+        d->filters.remove(index);
+    }
     return ret;
 }
 
@@ -320,6 +324,8 @@ int QAVMuxerFrames::writeFilters(const QAVFrame &frame, int index, Locker &locke
             if (ret != AVERROR(ENOTSUP) || !frame || retried)
                 return ret;
             ret = applyFilters(frame, index, locker);
+            if (ret < 0)
+                return ret;
             retried = true;
             continue;
         }
@@ -373,11 +379,8 @@ int QAVMuxerFrames::writeFrame(const QAVFrame &frame, int index, Locker &locker)
                 auto filter = scaleFilter(AVPixelFormat(frame.frame()->format), encSize);
                 d->filterDescs[index] = filter;
                 int ret = applyFilters(frame, index, locker);
-                if (ret < 0) {
-                    d->filterDescs.remove(index);
-                    d->filters.remove(index);
+                if (ret < 0)
                     return ret;
-                }
             }
         }
     }

--- a/src/QtAVPlayer/qavmuxerframes.cpp
+++ b/src/QtAVPlayer/qavmuxerframes.cpp
@@ -12,6 +12,7 @@
 #include "qavsubtitlecodec_p.h"
 #include "qavvideoframe.h"
 #include "qavformatcontext_p.h"
+#include "qavfilters_p.h"
 
 #include <QThread>
 #include <QWaitCondition>
@@ -39,6 +40,8 @@ public:
     QList<QAVFrame> frames;
     QWaitCondition cond;
     bool quit = false;
+    QString filterDesc;
+    QAVFilters filters;
 
     void doWork();
 };
@@ -62,7 +65,7 @@ void QAVMuxerFramesPrivate::doWork()
         // Ignore wrong frames
         if (index < 0)
             continue;
-        q->write(frame, index, locker);
+        q->writeFrame(frame, index, locker);
     }
 }
 
@@ -270,6 +273,105 @@ int QAVMuxerFrames::initStream(const EncoderStream &encoderStream, int index, AV
     return 0;
 }
 
+int QAVMuxerFrames::applyFilters(const QAVFrame &frame, Locker &)
+{
+    Q_D(QAVMuxerFrames);
+    QAVStream videoStream;
+    QAVStream audioStream;
+    switch (frame.stream().stream()->codecpar->codec_type) {
+    case AVMEDIA_TYPE_VIDEO:
+        videoStream = frame.stream();
+        break;
+    default:
+        // For now only video filters are supported
+        qWarning() << "Unsupported codec type:" << frame.stream().stream()->codecpar->codec_type;
+        return AVERROR(ENOTSUP);
+    }
+    int ret = d->filters.createFilters(
+        {d->filterDesc},
+        frame,
+        videoStream,
+        audioStream);
+    return ret;
+}
+
+int QAVMuxerFrames::writeFilters(const QAVFrame &frame, int index, Locker &locker)
+{
+    Q_D(QAVMuxerFrames);
+    QList<QAVFrame> filteredFrames;
+    auto stream = frame.stream().stream();
+    int ret = 0;
+    if (frame) {
+        ret = d->filters.write(stream->codecpar->codec_type, frame);
+        if (ret >= 0 || ret == AVERROR(EAGAIN))
+            ret = d->filters.read(stream->codecpar->codec_type, frame, filteredFrames);
+        if (ret < 0 && ret != AVERROR(EAGAIN)) {
+            // Try filters again
+            filteredFrames.clear();
+            if (ret != AVERROR(ENOTSUP))
+                return ret;
+            ret = applyFilters(frame, locker);
+            if (ret < 0)
+                return ret;
+        }
+    } else {
+        filteredFrames.push_back(frame);
+    }
+    while (!filteredFrames.isEmpty()) {
+        auto &filteredFrame = filteredFrames.front();
+        ret = write(filteredFrame, index, locker);
+        if (ret < 0 && ret != AVERROR(EAGAIN))
+            break;
+        if (ret != AVERROR(EAGAIN))
+            filteredFrames.pop_front();
+    }
+    return ret;
+}
+
+static QString scaleFilter(AVPixelFormat fmt, const QSize &size)
+{
+    QString filter = QLatin1String("scale");
+    switch (fmt) {
+    case AV_PIX_FMT_CUDA:
+        filter = QLatin1String("scale_cuda");
+        break;
+    case AV_PIX_FMT_VAAPI:
+        filter = QLatin1String("scale_vaapi");
+        break;
+    case AV_PIX_FMT_D3D11:
+        filter = QLatin1String("scale_d3d11");
+        break;
+    default:
+        break;
+    }
+    return QString(QLatin1String("%1=%2:%3")).arg(filter).arg(size.width()).arg(size.height());
+}
+
+int QAVMuxerFrames::writeFrame(const QAVFrame &frame, int index, Locker &locker)
+{
+    Q_D(QAVMuxerFrames);
+    auto &encStream = d->encStreams[index];
+    auto enc_ctx = encStream.codec()->avctx();
+    // Check if the size is the same as encoder
+    if (enc_ctx->codec_type == AVMEDIA_TYPE_VIDEO) {
+        QSize frameSize(frame.frame()->width, frame.frame()->height);
+        QSize encSize(enc_ctx->width, enc_ctx->height);
+        // If the size of the frame differs to the encoder's
+        // then need to implicitly resize the frame using a filter.
+        if (frameSize != encSize) {
+            if (d->filterDesc.isEmpty()) {
+                auto filter = scaleFilter(AVPixelFormat(frame.frame()->format), encSize);
+                d->filterDesc = filter;
+                int ret = applyFilters(frame, locker);
+                if (ret < 0)
+                    return ret;
+            }
+            return writeFilters(frame, index, locker);
+        }
+    }
+    return write(frame, index, locker);
+}
+
 int QAVMuxerFrames::write(const QAVFrame &frame)
 {
     Q_D(QAVMuxerFrames);
@@ -279,7 +381,7 @@ int QAVMuxerFrames::write(const QAVFrame &frame)
     int index = d->outputStreamIndex(frame.stream(), locker);
     if (index < 0)
         return AVERROR(EINVAL);
-    return write(frame, index, locker);
+    return writeFrame(frame, index, locker);
 }
 
 int QAVMuxerFrames::write(const QAVSubtitleFrame &frame)

--- a/src/QtAVPlayer/qavmuxerframes.cpp
+++ b/src/QtAVPlayer/qavmuxerframes.cpp
@@ -372,8 +372,10 @@ int QAVMuxerFrames::writeFrame(const QAVFrame &frame, int index, Locker &locker)
                 auto filter = scaleFilter(AVPixelFormat(frame.frame()->format), encSize);
                 d->filterDescs[index] = filter;
                 int ret = applyFilters(frame, index, locker);
-                if (ret < 0)
+                if (ret < 0) {
+                    d->filterDescs.clear();
                     return ret;
+                }
             }
         }
     }

--- a/src/QtAVPlayer/qavmuxerframes.cpp
+++ b/src/QtAVPlayer/qavmuxerframes.cpp
@@ -307,24 +307,24 @@ int QAVMuxerFrames::writeFilters(const QAVFrame &frame, int index, Locker &locke
     auto enc_ctx = encStream.codec()->avctx();
     int ret = 0;
     // Try to re-apply filters on error
-    bool retry = false;
-    do {
+    bool retried = false;
+    while (true) {
         if (frame)
             ret = d->filters[index]->write(enc_ctx->codec_type, frame);
+        // EAGAIN means write the next frame
         if (ret >= 0 || ret == AVERROR(EAGAIN))
             ret = d->filters[index]->read(enc_ctx->codec_type, frame, filteredFrames);
         if (ret < 0 && ret != AVERROR(EAGAIN)) {
             // Try filters again
             filteredFrames.clear();
-            if (ret != AVERROR(ENOTSUP) || !frame || retry)
+            if (ret != AVERROR(ENOTSUP) || !frame || retried)
                 return ret;
             ret = applyFilters(frame, index, locker);
-            if (ret < 0) {
-                retry = true;
-                continue;
-            }
+            retried = true;
+            continue;
         }
-    } while (retry);
+        break;
+    }
     if (ret < 0)
         return ret;
     while (!filteredFrames.isEmpty()) {

--- a/src/QtAVPlayer/qavmuxerframes.h
+++ b/src/QtAVPlayer/qavmuxerframes.h
@@ -71,7 +71,7 @@ private:
     void init(Locker &);
     int initStream(const EncoderStream &stream, int index, AVStream *out_stream, Locker &);
     // Applies requested filters
-    int applyFilters(const QAVFrame &frame, Locker &);
+    int applyFilters(const QAVFrame &frame, int index, Locker &);
     // Writes the frame to the filters and then writes to muxer
     int writeFilters(const QAVFrame &frame, int index, Locker &);
     // Checks if filters should be applied

--- a/src/QtAVPlayer/qavmuxerframes.h
+++ b/src/QtAVPlayer/qavmuxerframes.h
@@ -70,6 +70,12 @@ private:
     int initStreams(const QList<EncoderStream> &streams, Locker &);
     void init(Locker &);
     int initStream(const EncoderStream &stream, int index, AVStream *out_stream, Locker &);
+    // Applies requested filters
+    int applyFilters(const QAVFrame &frame, Locker &);
+    // Writes the frame to the filters and then writes to muxer
+    int writeFilters(const QAVFrame &frame, int index, Locker &);
+    // Checks if filters should be applied
+    int writeFrame(const QAVFrame &frame, int index, Locker &);
     // Need to make a copy of frame
     // streamIndex is needed to flush empty frame
     int write(QAVFrame frame, int streamIndex, Locker &);

--- a/tests/auto/integration/qavdemuxer/tst_qavdemuxer.cpp
+++ b/tests/auto/integration/qavdemuxer/tst_qavdemuxer.cpp
@@ -1008,7 +1008,10 @@ void tst_QAVDemuxer::muxerFramesScale()
             QVERIFY(fs.size() == 1);
             auto &f = fs[0];
             QVERIFY(f);
-            m.write(f);
+            if (f.stream().stream()->codecpar->codec_type == AVMEDIA_TYPE_VIDEO)
+                QVERIFY(m.write(f) >= 0);
+            else
+                QVERIFY(m.write(f) < 0);
         }
     }
     QTRY_VERIFY(m.size() == 0);

--- a/tests/auto/integration/qavdemuxer/tst_qavdemuxer.cpp
+++ b/tests/auto/integration/qavdemuxer/tst_qavdemuxer.cpp
@@ -62,6 +62,8 @@ private slots:
     void muxerWritePacketsFromDev();
     void muxerFramesEncoderStreams();
     void muxerFramesScaleHW();
+    void muxerFramesScale_data();
+    void muxerFramesScale();
 };
 
 void tst_QAVDemuxer::construction()
@@ -917,7 +919,6 @@ void tst_QAVDemuxer::muxerFramesScaleHW()
     for (auto &s : d.availableVideoStreams()) {
         QVERIFY(s.codec());
         QCOMPARE(s.codec()->size(), QSize(560, 320));
-        // It does not rescale, sets output size only
         QAVMuxerFrames::EncoderStream stream(s);
         stream.size = size;
         encoderStreams.push_back(stream);
@@ -959,6 +960,67 @@ void tst_QAVDemuxer::muxerFramesScaleHW()
         QCOMPARE(s.codec()->size(), size);
     }
 #endif
+}
+
+void tst_QAVDemuxer::muxerFramesScale_data()
+{
+    QTest::addColumn<QString>("decoder");
+    QTest::addColumn<QString>("encoder");
+    QTest::newRow("software") << "software" << "";
+#if defined(QT_AVPLAYER_CUDA)
+    QTest::newRow("cuda") << "h264_cuvid" << "h264_nvenc";
+#endif
+}
+
+void tst_QAVDemuxer::muxerFramesScale()
+{
+    QFETCH(QString, decoder);
+    QFETCH(QString, encoder);
+    QFileInfo file(testData("small.mp4"));
+    QAVDemuxer d;
+
+    d.setInputVideoCodec(decoder);
+    QVERIFY(d.load(file.absoluteFilePath()) >= 0);
+    QVERIFY(!d.currentVideoStreams().isEmpty());
+    auto codec = d.currentVideoStreams()[0].codec();
+    QVERIFY(codec);
+    QVERIFY(!d.availableVideoStreams().isEmpty());
+    QSize size(128, 96);
+    QList<QAVMuxerFrames::EncoderStream> encoderStreams;
+    for (auto &s : d.availableVideoStreams()) {
+        QVERIFY(s.codec());
+        QCOMPARE(s.codec()->size(), QSize(560, 320));
+        QAVMuxerFrames::EncoderStream stream(s);
+        // It should rescale
+        stream.size = size;
+        stream.codec = encoder;
+        encoderStreams.push_back(stream);
+    }
+
+    QAVMuxerFrames m;
+    QVERIFY(m.load(encoderStreams, "small.mkv") >= 0);
+
+    QAVPacket p;
+    while (d.read(p) >= 0) {
+        QList<QAVFrame> fs;
+        QAVDemuxer::decode(p, fs);
+        if (fs.size()) {
+            QVERIFY(fs.size() == 1);
+            auto &f = fs[0];
+            QVERIFY(f);
+            m.write(f);
+        }
+    }
+    QTRY_VERIFY(m.size() == 0);
+    QVERIFY(m.flush() >= 0);
+    m.unload();
+    d.unload();
+    QVERIFY(d.load("small.mkv") >= 0);
+    QVERIFY(!d.availableVideoStreams().isEmpty());
+    for (auto &s : d.availableVideoStreams()) {
+        QVERIFY(s.codec());
+        QCOMPARE(s.codec()->size(), size);
+    }
 }
 
 QTEST_MAIN(tst_QAVDemuxer)

--- a/tests/auto/integration/qavplayer/tst_qavplayer.cpp
+++ b/tests/auto/integration/qavplayer/tst_qavplayer.cpp
@@ -3820,7 +3820,7 @@ void tst_QAVPlayer::muxerScale()
     QAVVideoFrame vf;
     QObject::connect(&p2, &QAVPlayer::videoFrame, &p2, [&](const QAVVideoFrame &f) {
         vf = f;
-    });
+    }, Qt::QueuedConnection);
 
     p2.setSource("output.mkv");
     QTRY_VERIFY(p2.mediaStatus() == QAVPlayer::LoadedMedia);

--- a/tests/auto/integration/qavplayer/tst_qavplayer.cpp
+++ b/tests/auto/integration/qavplayer/tst_qavplayer.cpp
@@ -3691,6 +3691,8 @@ void tst_QAVPlayer::muxerScaleHW()
 
     p.play();
     QTRY_VERIFY(p.mediaStatus() == QAVPlayer::EndOfMedia);
+    QTRY_VERIFY(m.size() == 0);
+    QVERIFY(m.flush() >= 0);
     m.unload();
 
     QAVPlayer p2;
@@ -3750,6 +3752,8 @@ void tst_QAVPlayer::muxerScaleHWSplit()
 
     p.play();
     QTRY_VERIFY(p.mediaStatus() == QAVPlayer::EndOfMedia);
+    QTRY_VERIFY(m.size() == 0);
+    QVERIFY(m.flush() >= 0);
     m.unload();
 
     QAVPlayer p2;
@@ -3808,6 +3812,8 @@ void tst_QAVPlayer::muxerScale()
 
     p.play();
     QTRY_VERIFY(p.mediaStatus() == QAVPlayer::EndOfMedia);
+    QTRY_VERIFY(m.size() == 0);
+    QVERIFY(m.flush() >= 0);
     m.unload();
 
     QAVPlayer p2;

--- a/tests/auto/integration/qavplayer/tst_qavplayer.cpp
+++ b/tests/auto/integration/qavplayer/tst_qavplayer.cpp
@@ -113,6 +113,8 @@ private slots:
     void scaleHW();
     void muxerScaleHW();
     void muxerScaleHWSplit();
+    void muxerScale_data();
+    void muxerScale();
 };
 
 void tst_QAVPlayer::initTestCase()
@@ -3742,6 +3744,64 @@ void tst_QAVPlayer::muxerScaleHWSplit()
         QAVMuxerFrames::EncoderStream stream(s);
         stream.size = size;
         stream.codec = codec;
+        encoderStreams.push_back(stream);
+    }
+    QVERIFY(m.load(encoderStreams, "output.mkv") >= 0);
+
+    p.play();
+    QTRY_VERIFY(p.mediaStatus() == QAVPlayer::EndOfMedia);
+    m.unload();
+
+    QAVPlayer p2;
+    QAVVideoFrame vf;
+    QObject::connect(&p2, &QAVPlayer::videoFrame, &p2, [&](const QAVVideoFrame &f) {
+        vf = f;
+    });
+
+    p2.setSource("output.mkv");
+    QTRY_VERIFY(p2.mediaStatus() == QAVPlayer::LoadedMedia);
+    p2.pause();
+    QTRY_VERIFY(vf);
+    QCOMPARE(vf.size(), size);
+}
+
+void tst_QAVPlayer::muxerScale_data()
+{
+    QTest::addColumn<QString>("decoder");
+    QTest::addColumn<QString>("encoder");
+    QTest::newRow("software") << "software" << "";
+#if defined(QT_AVPLAYER_CUDA)
+    QTest::newRow("cuda") << "h264_cuvid" << "h264_nvenc";
+#endif
+}
+
+void tst_QAVPlayer::muxerScale()
+{
+    QFETCH(QString, decoder);
+    QFETCH(QString, encoder);
+    QAVMuxerFrames m;
+    QAVPlayer p;
+    p.setSynced(false);
+    QSize size(160, 120);
+
+    p.setInputVideoCodec(decoder);
+    p.setSource(QFileInfo(testData("small.mp4")).absoluteFilePath());
+
+    QObject::connect(&p, &QAVPlayer::videoFrame, &p, [&](const QAVVideoFrame &f) {
+        m.enqueue(f);
+    }, Qt::DirectConnection);
+
+    QTRY_VERIFY(p.mediaStatus() == QAVPlayer::LoadedMedia);
+    auto videoStreams = p.availableVideoStreams();
+    QCOMPARE(videoStreams.size(), 1);
+    auto c = videoStreams[0].codec();
+    QVERIFY(c);
+    QCOMPARE(c->size(), QSize(560, 320));
+    QList<QAVMuxerFrames::EncoderStream> encoderStreams;
+    for (auto &s : videoStreams) {
+        QAVMuxerFrames::EncoderStream stream(s);
+        stream.size = size;
+        stream.codec = encoder;
         encoderStreams.push_back(stream);
     }
     QVERIFY(m.load(encoderStreams, "output.mkv") >= 0);


### PR DESCRIPTION
`QAVMuxerFrames` accepts `EncoderStream` with the size. If the frame has different size to requested one, now the frame should be scaled implicitly using a filter based on the pixel format.
If the pixel format is software based, then `scale` filter is used:
`cuda` -> `scale_cuda`
`vaapi` -> `scale_vaapi`
`d3d11` -> `scale_d3d11`