### PR TITLE
Move filtering of streams from demuxer to decoder threads

### DIFF
--- a/src/QtAVPlayer/qavpacketqueue_p.h
+++ b/src/QtAVPlayer/qavpacketqueue_p.h
@@ -161,8 +161,14 @@ public:
         QMutexLocker locker(&m_mutex);
         if (m_decodedFrames.isEmpty()) {
             auto pkt = dequeue();
-            if (m_demuxer.currentCodecType(pkt.packet()->stream_index) == m_mediaType)
+            if (pkt.packet()->stream_index != AVMEDIA_TYPE_UNKNOWN
+                && m_demuxer.currentCodecType(pkt.packet()->stream_index) == m_mediaType)
+            {
+                // Keep the lock during the decoding to prevent
+                // a race between clearPackets() and when the decoding is finished.
+                // Empty packet flushes the codes here.
                 QAVDemuxer::decode(pkt, m_decodedFrames);
+            }
         }
         if (m_decodedFrames.isEmpty())
             return false;

--- a/src/QtAVPlayer/qavpacketqueue_p.h
+++ b/src/QtAVPlayer/qavpacketqueue_p.h
@@ -161,13 +161,8 @@ public:
         QMutexLocker locker(&m_mutex);
         if (m_decodedFrames.isEmpty()) {
             auto pkt = dequeue();
-            if (m_demuxer.currentCodecType(pkt.packet()->stream_index) == m_mediaType) {
-                locker.unlock();
-                QList<T> frames;
-                QAVDemuxer::decode(pkt, frames);
-                locker.relock();
-                m_decodedFrames = frames;
-            }
+            if (m_demuxer.currentCodecType(pkt.packet()->stream_index) == m_mediaType)
+                QAVDemuxer::decode(pkt, m_decodedFrames);
         }
         if (m_decodedFrames.isEmpty())
             return false;

--- a/src/QtAVPlayer/qavpacketqueue_p.h
+++ b/src/QtAVPlayer/qavpacketqueue_p.h
@@ -161,8 +161,13 @@ public:
         QMutexLocker locker(&m_mutex);
         if (m_decodedFrames.isEmpty()) {
             auto pkt = dequeue();
-            if (m_demuxer.currentCodecType(pkt.packet()->stream_index) == m_mediaType)
-                QAVDemuxer::decode(pkt, m_decodedFrames);
+            if (m_demuxer.currentCodecType(pkt.packet()->stream_index) == m_mediaType) {
+                locker.unlock();
+                QList<T> frames;
+                QAVDemuxer::decode(pkt, frames);
+                locker.relock();
+                m_decodedFrames = frames;
+            }
         }
         if (m_decodedFrames.isEmpty())
             return false;

--- a/src/QtAVPlayer/qavpacketqueue_p.h
+++ b/src/QtAVPlayer/qavpacketqueue_p.h
@@ -122,8 +122,9 @@ template<class T>
 class QAVPacketQueue
 {
 public:
-    QAVPacketQueue(AVMediaType mediaType)
+    QAVPacketQueue(AVMediaType mediaType, QAVDemuxer &demuxer)
         : m_mediaType(mediaType)
+        , m_demuxer(demuxer)
     {
     }
 
@@ -158,8 +159,11 @@ public:
     bool frontFrame(T &frame)
     {
         QMutexLocker locker(&m_mutex);
-        if (m_decodedFrames.isEmpty())
-            QAVDemuxer::decode(dequeue(), m_decodedFrames);
+        if (m_decodedFrames.isEmpty()) {
+            auto pkt = dequeue();
+            if (m_demuxer.currentCodecType(pkt.packet()->stream_index) == m_mediaType)
+                QAVDemuxer::decode(pkt, m_decodedFrames);
+        }
         if (m_decodedFrames.isEmpty())
             return false;
         frame = m_decodedFrames.front();
@@ -257,6 +261,7 @@ private:
     }
 
     const AVMediaType m_mediaType = AVMEDIA_TYPE_UNKNOWN;
+    QAVDemuxer &m_demuxer;
     QList<QAVPacket> m_packets;
     // Tracks decoded frames to prevent EOF if not all frames are landed
     QList<T> m_decodedFrames;

--- a/src/QtAVPlayer/qavplayer.cpp
+++ b/src/QtAVPlayer/qavplayer.cpp
@@ -48,9 +48,9 @@ class QAVPlayerPrivate
 public:
     QAVPlayerPrivate(QAVPlayer *q)
         : q_ptr(q)
-        , videoQueue(AVMEDIA_TYPE_VIDEO)
-        , audioQueue(AVMEDIA_TYPE_AUDIO)
-        , subtitleQueue(AVMEDIA_TYPE_SUBTITLE)
+        , videoQueue(AVMEDIA_TYPE_VIDEO, demuxer)
+        , audioQueue(AVMEDIA_TYPE_AUDIO, demuxer)
+        , subtitleQueue(AVMEDIA_TYPE_SUBTITLE, demuxer)
     {
         threadPool.setMaxThreadCount(4);
     }
@@ -655,18 +655,18 @@ void QAVPlayerPrivate::doDemux()
             muxer.write(packet);
             endOfFile(false);
             // Empty packet points to EOF and it needs to flush codecs
-            switch (demuxer.currentCodecType(packet.packet()->stream_index)) {
-                case AVMEDIA_TYPE_VIDEO:
-                    videoQueue.enqueue(packet);
-                    break;
-                case AVMEDIA_TYPE_AUDIO:
-                    audioQueue.enqueue(packet);
-                    break;
-                case AVMEDIA_TYPE_SUBTITLE:
-                    subtitleQueue.enqueue(packet);
-                    break;
-                default:
-                    break;
+            switch (packet.stream().stream()->codecpar->codec_type) {
+            case AVMEDIA_TYPE_VIDEO:
+                videoQueue.enqueue(packet);
+                break;
+            case AVMEDIA_TYPE_AUDIO:
+                audioQueue.enqueue(packet);
+                break;
+            case AVMEDIA_TYPE_SUBTITLE:
+                subtitleQueue.enqueue(packet);
+                break;
+            default:
+                break;
             }
         } else {
             if (ret < 0 && ret != AVERROR_EOF) {
@@ -764,6 +764,7 @@ void QAVPlayerPrivate::doPlayStep(
     // 1. Decode a frame
     QAVFrame decodedFrame;
     queue.frontFrame(decodedFrame);
+    // If no decoded frames, it still needs to drain filters by filters.read
     bool flushEvents = false;
     int ret = 0;
 


### PR DESCRIPTION
Demuxer thread reads _all_ packets from all streams. But the player is interested to play only specific streams.
Then the packets from specific streams are enqueued for decoding, other packets are ignored.

This leads to scenario when a user changes the stream and it takes few milliseconds or even seconds when correct frames are returned.

To fix the immediate changing of the stream, all packets should be placed to the queues and the decoder threads could ignore not interesting packets.