### PR TITLE
Don't implicitly convert while casting to QVideoFrame

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ player->setSource("subfile,,start,0,end,0,,:/root/Downloads/why-qtmm-must-die.mk
 ```cpp
 QObject::connect(player, &QAVPlayer::videoFrame, player,
     [&](const QAVVideoFrame &frame) {
-        // Compatible with QVideoFrame and copy-free for supported formats
+        // Compatible with QVideoFrame and copy-free
         QVideoFrame videoFrame = frame; // or frame.toQVideoFrame();
 
         // Convert to a different pixel format on CPU
@@ -192,7 +192,7 @@ QObject::connect(player, &QAVPlayer::videoFrame, w,
     }, Qt::DirectConnection);
 ```
 
-- Since `QAVVideoFrame` is compatible with `QVideoFrame`, `QtMultimedia` can render frames directly to QML or Widgets — see the [examples](https://github.com/valbok/QtAVPlayer/blob/master/examples/qml_video). Converting to `QVideoFrame` is copy-free for supported pixel formats.
+- Since `QAVVideoFrame` is compatible with `QVideoFrame`, `QtMultimedia` can render frames directly to QML or Widgets — see the [examples](https://github.com/valbok/QtAVPlayer/blob/master/examples/qml_video). Converting to `QVideoFrame` is copy-free.
 
 ```cpp
 QObject::connect(player, &QAVPlayer::videoFrame, this,

--- a/examples/qml_video/main.cpp
+++ b/examples/qml_video/main.cpp
@@ -172,6 +172,7 @@ int main(int argc, char *argv[])
                 QObject::connect(&p, &QAVPlayer::audioFrame, &p, [&](const QAVAudioFrame &f) { muxer.enqueue(f); }, Qt::DirectConnection);
                 QObject::connect(&p, &QAVPlayer::subtitleFrame, &p, [&](const QAVSubtitleFrame &f) { muxer.write(f); }, Qt::DirectConnection);
             }
+            qDebug() << "Chapters:" << p.chapters();
             p.play();
         } else if (status == QAVPlayer::EndOfMedia) {
             for (const auto &s : p.availableVideoStreams())

--- a/src/QtAVPlayer/qavvideoframe.cpp
+++ b/src/QtAVPlayer/qavvideoframe.cpp
@@ -453,15 +453,11 @@ QAVVideoFrame::operator QVideoFrame() const
         case AV_PIX_FMT_YUV420P:
             format = VideoFrame::Format_YUV420P;
             break;
-        case AV_PIX_FMT_YUV444P:
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
         case AV_PIX_FMT_YUV422P:
-#if QT_VERSION < QT_VERSION_CHECK(5, 15, 0)
-            result = convertTo(AV_PIX_FMT_YUV420P);
-            format = VideoFrame::Format_YUV420P;
-#else
             format = VideoFrame::Format_YUV422P;
-#endif
             break;
+#endif
         case AV_PIX_FMT_VAAPI:
         case AV_PIX_FMT_VDPAU:
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
@@ -488,10 +484,8 @@ QAVVideoFrame::operator QVideoFrame() const
             break;
 #endif
         default:
-            // TODO: Add more supported formats instead of converting
-            result = convertTo(AV_PIX_FMT_YUV420P);
-            format = VideoFrame::Format_YUV420P;
-            break;
+            qWarning() << formatName() << "is not supported";
+            return {};
     }
 
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)

--- a/src/QtAVPlayer/qavvideoframe.h
+++ b/src/QtAVPlayer/qavvideoframe.h
@@ -67,8 +67,9 @@ public:
     QString formatName() const;
     QAVVideoFrame convertTo(AVPixelFormat fmt, const QSize &requestedSize = {}) const;
 #ifdef QT_AVPLAYER_MULTIMEDIA
-    // Implicitly converts to QVideoFrame.
-    // Automatically converts to a supported pixel format if necessary.
+    // Implicitly converts to QVideoFrame with zero-copy.
+    // Returns an invalid QVideoFrame if the pixel format isn't supported by QtMultimedia.
+    // Use convertTo() if needed.
     operator QVideoFrame() const;
     QVideoFrame toQVideoFrame() const;
 #endif

--- a/tests/auto/integration/qavplayer/tst_qavplayer.cpp
+++ b/tests/auto/integration/qavplayer/tst_qavplayer.cpp
@@ -1855,7 +1855,7 @@ void tst_QAVPlayer::cast2QVideoFrame_data()
 
     QTest::newRow("colors.mp4") << testData("colors.mp4") << QSize(160, 120);
     QTest::newRow("dv_dsf_1_stype_1.dv") << testData("dv_dsf_1_stype_1.dv") << QSize(720, 576);
-    QTest::newRow("dv25_pal__411_4-3_2ch_32k_bars_sine.dv") << testData("dv25_pal__411_4-3_2ch_32k_bars_sine.dv") << QSize(720, 576);
+    //QTest::newRow("dv25_pal__411_4-3_2ch_32k_bars_sine.dv") << testData("dv25_pal__411_4-3_2ch_32k_bars_sine.dv") << QSize(720, 576); -- "yuv411p" is not supported
     QTest::newRow("small.mp4") << testData("small.mp4") << QSize(560, 320);
     QTest::newRow("Earth_Zoom_In.mov") << testData("Earth_Zoom_In.mov") << QSize(1920, 1080);
 }


### PR DESCRIPTION
1. Removed support of `AV_PIX_FMT_YUV444P` since it is not supported by QtMultimedia.
2. Removed implicit converting to default pixel format. Now user should decide.