### PR TITLE
Introduce Vulkan support

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,6 +426,7 @@ QtAVPlayer is meant to be bundled directly into your application. A few compile-
 |--------|---------|
 | `QT_AVPLAYER_MULTIMEDIA` | `QtMultimedia` support (requires `QtGUI`, `QtQuick`, etc.) |
 | `QT_AVPLAYER_CUDA` | CUDA support |
+| `QT_AVPLAYER_VULKAN` | Vulkan support |
 | `QT_AVPLAYER_VA_X11` | `libva-x11` hardware acceleration (Linux only) |
 | `QT_AVPLAYER_VA_DRM` | `libva-drm` hardware acceleration (Linux only) |
 | `QT_AVPLAYER_VDPAU` | `libvdpau` hardware acceleration (Linux only) |

--- a/src/QtAVPlayer/QtAVPlayer.cmake
+++ b/src/QtAVPlayer/QtAVPlayer.cmake
@@ -9,6 +9,7 @@ option(QT_AVPLAYER_VDPAU "Enable vdpau" OFF)
 option(QT_AVPLAYER_WIDGET_OPENGL "Enable widget opengl" OFF)
 option(QT_AVPLAYER_LIBASS "Enable libass" OFF)
 option(QT_AVPLAYER_CUDA "Enable CUDA" OFF)
+option(QT_AVPLAYER_VULKAN "Enable Vulkan" OFF)
 
 find_library(AVDEVICE_LIBRARY REQUIRED NAMES avdevice)
 find_library(AVCODEC_LIBRARY REQUIRED NAMES avcodec)
@@ -61,6 +62,7 @@ set(QtAVPlayer_PRIVATE_HEADERS
     ${QT_AVPLAYER_DIR}/qavaudioconverter_p.h
     ${QT_AVPLAYER_DIR}/qavformatcontext_p.h
     ${QT_AVPLAYER_DIR}/qavhwdevice_cuda_p.h.h
+    ${QT_AVPLAYER_DIR}/qavhwdevice_vulkan_p.h.h
 )
 
 set(QtAVPlayer_PUBLIC_HEADERS
@@ -118,6 +120,7 @@ set(QtAVPlayer_SOURCES
     ${QT_AVPLAYER_DIR}/qavformatcontext.cpp
     ${QT_AVPLAYER_DIR}/qavhwdevice_cuda.cpp
     ${QT_AVPLAYER_DIR}/qavchapter.cpp
+    ${QT_AVPLAYER_DIR}/qavhwdevice_vulkan.cpp
 )
 
 if(WIN32)
@@ -309,4 +312,9 @@ if(QT_AVPLAYER_CUDA)
     message(STATUS "QT_AVPLAYER_CUDA is defined")
     find_library(LIBASS_LIBRARY REQUIRED NAMES cuda)
     add_definitions(-DQT_AVPLAYER_CUDA)
+endif()
+
+if(QT_AVPLAYER_VULKAN)
+    message(STATUS "QT_AVPLAYER_VULKAN is defined")
+    add_definitions(-DQT_AVPLAYER_VULKAN)
 endif()

--- a/src/QtAVPlayer/QtAVPlayer.pri
+++ b/src/QtAVPlayer/QtAVPlayer.pri
@@ -34,6 +34,7 @@ PRIVATE_HEADERS += \
     $$PWD/qavaudioconverter_p.h \
     $$PWD/qavformatcontext_p.h \
     $$PWD/qavhwdevice_cuda_p.h \
+    $$PWD/qavhwdevice_vulkan_p.h \
 
 PUBLIC_HEADERS += \
     $$PWD/qaviodevice.h \
@@ -89,6 +90,7 @@ SOURCES += \
     $$PWD/qavformatcontext.cpp \
     $$PWD/qavhwdevice_cuda.cpp \
     $$PWD/qavchapter.cpp \
+    $$PWD/qavhwdevice_vulkan.cpp \
 
 contains(DEFINES, QT_AVPLAYER_MULTIMEDIA) {
     QT += multimedia

--- a/src/QtAVPlayer/qavdemuxer.cpp
+++ b/src/QtAVPlayer/qavdemuxer.cpp
@@ -44,6 +44,7 @@ extern "C" {
 #endif
 
 #include "qavhwdevice_cuda_p.h"
+#include "qavhwdevice_vulkan_p.h"
 
 #include <QDir>
 #include <QSharedPointer>
@@ -229,6 +230,11 @@ static int setup_video_codec(const QString &inputVideoCodec, const QAVStream &st
     QAVDictionaryHolder opts;
     Q_UNUSED(opts);
 
+#if defined(QT_AVPLAYER_VULKAN)
+    devices[AV_HWDEVICE_TYPE_VULKAN].reset(new QAVHWDevice_Vulkan);
+    // Keep vulkan first in the list of preferred devices
+    preferredDevices.push_back(AV_HWDEVICE_TYPE_VULKAN);
+#endif
 #if defined(QT_AVPLAYER_VA_X11) && QT_CONFIG(opengl)
     devices[AV_HWDEVICE_TYPE_VAAPI].reset(new QAVHWDevice_VAAPI_X11_GLX);
     preferredDevices.push_back(AV_HWDEVICE_TYPE_VAAPI);

--- a/src/QtAVPlayer/qavhwdevice_vulkan.cpp
+++ b/src/QtAVPlayer/qavhwdevice_vulkan.cpp
@@ -1,0 +1,34 @@
+/***************************************************************
+ * Copyright (C) 2020, 2026, Val Doroshchuk <valbok@gmail.com> *
+ *                                                             *
+ * This file is part of QtAVPlayer.                            *
+ * Free Qt Media Player based on FFmpeg.                       *
+ ***************************************************************/
+
+#include "qavhwdevice_vulkan_p.h"
+#include "qavvideobuffer_gpu_p.h"
+#include <QDebug>
+
+extern "C" {
+#include <libavutil/pixdesc.h>
+#include <libavcodec/avcodec.h>
+}
+
+QT_BEGIN_NAMESPACE
+
+AVPixelFormat QAVHWDevice_Vulkan::format() const
+{
+    return AV_PIX_FMT_VULKAN;
+}
+
+AVHWDeviceType QAVHWDevice_Vulkan::type() const
+{
+    return AV_HWDEVICE_TYPE_VULKAN;
+}
+
+QAVVideoBuffer *QAVHWDevice_Vulkan::videoBuffer(const QAVVideoFrame &frame) const
+{
+    return new QAVVideoBuffer_GPU(frame);
+}
+
+QT_END_NAMESPACE

--- a/src/QtAVPlayer/qavhwdevice_vulkan_p.h
+++ b/src/QtAVPlayer/qavhwdevice_vulkan_p.h
@@ -1,0 +1,43 @@
+/***************************************************************
+ * Copyright (C) 2020, 2026, Val Doroshchuk <valbok@gmail.com> *
+ *                                                             *
+ * This file is part of QtAVPlayer.                            *
+ * Free Qt Media Player based on FFmpeg.                       *
+ ***************************************************************/
+
+#ifndef QAVHWDEVICE_VULKAN_P_H
+#define QAVHWDEVICE_VULKAN_P_H
+
+//
+//  W A R N I N G
+//  -------------
+//
+// This file is not part of the Qt API. It exists purely as an
+// implementation detail. This header file may change from version to
+// version without notice, or even be removed.
+//
+// We mean it.
+//
+
+#include "qavhwdevice_p.h"
+#include <memory>
+
+QT_BEGIN_NAMESPACE
+
+class Q_AVPLAYER_EXPORT QAVHWDevice_Vulkan : public QAVHWDevice
+{
+public:
+    QAVHWDevice_Vulkan() = default;
+    ~QAVHWDevice_Vulkan() = default;
+
+    AVPixelFormat format() const override;
+    AVHWDeviceType type() const override;
+    QAVVideoBuffer *videoBuffer(const QAVVideoFrame &frame) const override;
+
+private:
+    Q_DISABLE_COPY(QAVHWDevice_Vulkan)
+};
+
+QT_END_NAMESPACE
+
+#endif

--- a/src/QtAVPlayer/qavvideoframe.cpp
+++ b/src/QtAVPlayer/qavvideoframe.cpp
@@ -475,6 +475,7 @@ QAVVideoFrame::operator QVideoFrame() const
         case AV_PIX_FMT_CUDA:
         case AV_PIX_FMT_D3D11:
         case AV_PIX_FMT_VIDEOTOOLBOX:
+        case AV_PIX_FMT_VULKAN:
         case AV_PIX_FMT_NV12:
             format = VideoFrame::Format_NV12;
             break;

--- a/tests/auto/integration/qavplayer/tst_qavplayer.cpp
+++ b/tests/auto/integration/qavplayer/tst_qavplayer.cpp
@@ -3645,6 +3645,11 @@ void tst_QAVPlayer::scaleHW()
     p.setFilter("scale_cuda=1920:1080");
     size = {1920, 1080};
 #endif
+#if defined(QT_AVPLAYER_VULKAN)
+    p.setInputVideoCodec("");
+    p.setFilter("scale_vulkan=1920:1080");
+    size = {1920, 1080};
+#endif
 #if defined(Q_OS_MACOS) || defined(Q_OS_IOS)
     p.setFilter("scale_vt=1920:1080");
     //size = {1920, 1080}; // TODO: ci could fail to initialize videotoolbox_vld


### PR DESCRIPTION
Using `-DQT_AVPLAYER_VULKAN=ON` enables Vulkan support.
If it is enabled, it will try to use `hwaccel` `vulkan` firstly.
To use another `hwaccel`, you would need to provide specific codec in `setInputVideoCodec()`.


```
h264 : supported hardware device contexts:
    cuda
    vaapi
    vdpau
    vulkan
Available pixel formats:
   yuv420p : AVPixelFormat( 0 )
   vdpau : AVPixelFormat( 98 )
   vulkan : AVPixelFormat( 190 )
   cuda : AVPixelFormat( 117 )
   vaapi : AVPixelFormat( 44 )
Using hardware decoding in vulkan
```