### PR TITLE
Introduce VulkanTextureHandle

### DIFF
--- a/examples/qml_video/main.cpp
+++ b/examples/qml_video/main.cpp
@@ -62,6 +62,7 @@ static bool isStreamCurrent(int index, const QList<QAVStream> &streams)
 
 int main(int argc, char *argv[])
 {
+    qputenv("QSG_RHI_BACKEND", "vulkan");
     QGuiApplication app(argc, argv);
 
     QQuickView viewer;

--- a/src/QtAVPlayer/qavhwdevice_vulkan.cpp
+++ b/src/QtAVPlayer/qavhwdevice_vulkan.cpp
@@ -9,9 +9,14 @@
 #include "qavvideobuffer_gpu_p.h"
 #include <QDebug>
 
+#if defined(QT_AVPLAYER_MULTIMEDIA) && QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+#include <private/qrhi_p.h>
+#endif
+
 extern "C" {
 #include <libavutil/pixdesc.h>
 #include <libavcodec/avcodec.h>
+#include <libavutil/hwcontext_vulkan.h>
 }
 
 QT_BEGIN_NAMESPACE
@@ -26,9 +31,53 @@ AVHWDeviceType QAVHWDevice_Vulkan::type() const
     return AV_HWDEVICE_TYPE_VULKAN;
 }
 
+#if defined(QT_AVPLAYER_MULTIMEDIA) && QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+
+class VideoBuffer_Vulkan: public QAVVideoBuffer_GPU
+{
+public:
+    VideoBuffer_Vulkan(const QAVVideoFrame &frame)
+        : QAVVideoBuffer_GPU(frame)
+    {
+    }
+
+    ~VideoBuffer_Vulkan()
+    {
+    }
+
+    QAVVideoFrame::HandleType handleType() const override
+    {
+        return QAVVideoFrame::VulkanTextureHandle;
+    }
+
+    QVariant handle(QRhi *rhi) const override
+    {
+        if (!rhi || rhi->backend() != QRhi::Vulkan)
+            return {};
+
+        AVFrame *av_frame = frame().frame();
+        AVVkFrame* vk_frame = (AVVkFrame*)av_frame->data[0];
+        VkImage singleVkImage = vk_frame->img[0];
+
+        QList<quint64> textures = {
+            reinterpret_cast<quint64>(singleVkImage),
+            reinterpret_cast<quint64>(singleVkImage)
+        };
+        return QVariant::fromValue(textures);
+    }
+};
+
+QAVVideoBuffer *QAVHWDevice_Vulkan::videoBuffer(const QAVVideoFrame &frame) const
+{
+    return new VideoBuffer_Vulkan(frame);
+}
+
+#else // #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+
 QAVVideoBuffer *QAVHWDevice_Vulkan::videoBuffer(const QAVVideoFrame &frame) const
 {
     return new QAVVideoBuffer_GPU(frame);
 }
 
+#endif
 QT_END_NAMESPACE

--- a/src/QtAVPlayer/qavvideoframe.cpp
+++ b/src/QtAVPlayer/qavvideoframe.cpp
@@ -506,6 +506,7 @@ QAVVideoFrame::operator QVideoFrame() const
             break;
         case MTLTextureHandle:
         case D3D11Texture2DHandle:
+        case VulkanTextureHandle:
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
             type = HandleType::RhiTextureHandle;
 #endif

--- a/src/QtAVPlayer/qavvideoframe.h
+++ b/src/QtAVPlayer/qavvideoframe.h
@@ -34,7 +34,8 @@ public:
         NoHandle,
         GLTextureHandle,
         MTLTextureHandle,
-        D3D11Texture2DHandle
+        D3D11Texture2DHandle,
+        VulkanTextureHandle
     };
 
     QAVVideoFrame();


### PR DESCRIPTION
```bash
$ QSG_RHI_BACKEND=vulkan ./qml_video ../../tests/auto/integration/testdata/DHC0413_CreaseOrNot.mp4
h264 : supported hardware device contexts:
    cuda
    vaapi
    vdpau
    vulkan
Available pixel formats:
   yuv420p : AVPixelFormat( 0 )
   vdpau : AVPixelFormat( 98 )
   vulkan : AVPixelFormat( 190 )
   cuda : AVPixelFormat( 117 )
   vaapi : AVPixelFormat( 44 )
Using hardware decoding in vulkan

```